### PR TITLE
Fix broken link to chroma directory in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -342,7 +342,7 @@ alt="image could not be loaded"
 style="color: red; background-color: black; font-weight: bold" />
 </div>
 
-<p>The <a href="https://github.com/z-shell/F-Sy-H/tree/main/%E2%86%92chroma">chromas</a> that are enabled by default can be found <a href="https://github.com/z-shell/F-Sy-H/blob/main/functions/fast-highlight#L172">here</a>.</p>
+<p>The <a href="https://github.com/z-shell/F-Sy-H/tree/main/chroma">chromas</a> that are enabled by default can be found <a href="https://github.com/z-shell/F-Sy-H/blob/main/functions/fast-highlight#L172">here</a>.</p>
 
   <hr /><h3 align="left">Math-mode highlighting</h3>
 


### PR DESCRIPTION
# Pull request template

Includes a correction for a link to the `chroma` directory in the repository.

## Type of changes

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

- [ ] CI
- [ ] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [X] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: N/A

## What is the current behavior?

The URL for the current link is `https://github.com/z-shell/F-Sy-H/tree/main/%E2%86%92chroma`, which is incorrect as this directory does not exist in the repository.

The URL includes encoding for the `→` character (right arrow), probably entered by mistake.

## What is the new behavior?

The correct URL for the directory is `https://github.com/z-shell/F-Sy-H/tree/main/chroma`.

The README has been updated accordingly.

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

N/A
