### PR TITLE
ci(labels): use canonical label names in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,15 @@
-documentation 📝:
+type:docs:
   - "docs/**/*.md"
   - "community/**/*.md"
   - "ecosystem/**/*.md"
-dependencies 📦:
+area:dependencies:
   - "package.json"
   - "pnpm-lock.yaml"
   - "yarn.lock"
-enhancement ✨:
+type:maintenance:
   - "functions/**"
   - "src/**"
   - "lib/**"
-maintenance 📈:
   - ".editorconfig"
   - ".gitattributes"
   - ".gitignore"
@@ -31,15 +30,7 @@ maintenance 📈:
   - "crowdin.yml"
   - "netlify.toml"
   - "tsconfig.json"
-i18n 🌐:
-  - "i18n/**"
-  - "docs/i18n/**"
-#annex 🌀:
-#  - "*"
-#package 📦:
-#  - 'ecosystem/packages/**/*.md'
-#  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/packages/**/*.md'
-plugin ⚙️:
+area:plugin:
   - "*.zsh"
-ci 🤖:
+area:ci:
   - ".github/workflows/*"


### PR DESCRIPTION
`.github/labeler.yml` referenced legacy labels that [z-shell/.github#467](https://github.com/z-shell/.github/issues/467) deleted across the organization.

| Was | Now |
| --- | --- |
| `documentation 📝` | `type:docs` |
| `dependencies 📦` | `area:dependencies` |
| `enhancement ✨` | `type:maintenance` |
| `maintenance 📈` | `type:maintenance` |
| `annex 🌀` / `plugin ⚙️` / `package 📦` | `area:annex` / `area:plugin` / `area:package` |
| `ci 🤖` | `area:ci` |
| `i18n 🌐` | removed |

## Why it matters even where the labeler is off

`actions/labeler` applies labels through the issues API, which **creates** a label that does not exist rather than failing. So a config naming deleted labels silently recreates them, undoing the org-wide cleanup, and nothing in CI reports it.

That is latent rather than active here, and the retraction in z-shell/.github#527 has the detail: across the organization the labeler either could not authenticate or was disabled, so no recreation has actually occurred. This change is what keeps it latent if the workflow is ever enabled or the token ever fixed.

## Three things worth a look rather than a skim

- **`enhancement ✨` and `maintenance 📈` both map to `type:maintenance`**, so their glob lists merge into a single key rather than being renamed one for one.
- **`i18n 🌐` is dropped, not translated.** It has no canonical equivalent and this repository has never used it. The only repository that does is `z-shell/wiki`, which does not drive it from a labeler config. It arrived from a Docusaurus-shaped template, which also explains any remaining `crowdin.yml`, `docusaurus.config.js`, or `netlify.toml` globs matching paths this repository does not have.
- **Commented-out blocks are gone.** The file is re-emitted from parsed YAML, which does not preserve comments. The removed blocks were disabled template leftovers, so nothing active is lost, but the diff is larger than a pure key rename.

Pruning the remaining template globs would be a real improvement and is deliberately left out, so this stays reviewable as a label-name correction.

## Verified

Parsed with `yaml.safe_load` and checked against `lib/labels.yml`: every resulting key is canonical, and the audit added in [z-shell/.github#529](https://github.com/z-shell/.github/pull/529) reports no findings for the result. Piloted in `z-shell/z-a-submods`, where after the equivalent change the labeler ran and applied the correct canonical label ([z-a-submods#7](https://github.com/z-shell/z-a-submods/pull/7)).

Part of z-shell/.github#527.
