### PR TITLE
fix(chroma): read zi subcommands from ZI[cmd-list] instead of duplicating

### DIFF
--- a/chroma/-zi.ch
+++ b/chroma/-zi.ch
@@ -7,6 +7,13 @@
 
 FAST_HIGHLIGHT[-zi.ch-chroma-def]=1
 
+# Canonical list of `zi' subcommands lives in zi's own ZI[cmd-list] (zi.zsh);
+# read it here instead of hand-maintaining a second copy that silently drifts
+# (e.g. #31, and the `version' subcommand added in z-shell/zi@b8248aa never
+# reaching this file). The literal fallback below is a frozen snapshot for
+# the rare case this chroma loads before `zi' has populated $ZI.
+local __zi_subcommands="${ZI[cmd-list]:-help|subcmds|icemods|analytics|man|self-update|times|zstatus|load|light|unload|snippet|ls|ice|<ice|specification>|update|status|report|delete|loaded|list|cd|create|edit|glance|stress|changes|recently|clist|completions|cclear|cdisable|cenable|creinstall|cuninstall|csearch|compinit|dtrace|dstart|dstop|dunload|dreport|dclear|compile|uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|module|add-fpath|run}"
+
 typeset -gA fsh__zi__chroma__def
 fsh__zi__chroma__def=(
     ##
@@ -17,7 +24,7 @@ fsh__zi__chroma__def=(
     subcmd:NULL "NULL_0_opt"
     NULL_0_opt "(-help|--help|-h)
                    <<>> NO-OP // ::chroma/main-chroma-std-aopt-action"
-    "subcommands" "(help|subcmds|icemods|analytics|man|self-update|times|zstatus|load|light|unload|snippet|ls|ice|<ice|specification>|update|status|report|delete|loaded|list|cd|create|edit|glance|stress|changes|recently|clist|completions|cclear|cdisable|cenable|creinstall|cuninstall|csearch|compinit|dtrace|dstart|dstop|dunload|dreport|dclear|compile|uncompile|compiled|cdlist|cdreplay|cdclear|srv|recall|env-whitelist|bindkeys|module|add-fpath|run)"
+    "subcommands" "(${__zi_subcommands})"
 
     ## }}}
 


### PR DESCRIPTION
## Problem

`chroma/-zi.ch` hand-maintains its own copy of `zi`'s subcommand list in
`fsh__zi__chroma__def["subcommands"]`. It drifts from `zi`'s own
`ZI[cmd-list]` (`zi.zsh`), the list `zi` itself uses to validate its
subcommands: `zi` added a `version` subcommand a while back
(z-shell/zi@b8248aa), but this file was never updated, so `zi version`
doesn't get highlighted as a recognized command. Same class of gap #31 fixed
in 2022.

## Fix

Read `ZI[cmd-list]` at chroma-load time (F-Sy-H's chroma functions load
after `zi` is already sourced) instead of a static literal, keeping the old
literal only as a frozen fallback for the rare case this chroma loads before
`zi` has populated `$ZI`. Any subcommand `zi` adds or removes going forward
is picked up automatically — no more manual syncing between the two repos.

## Verification

- `zsh -n chroma/-zi.ch` and `zcompile` both pass (matches this repo's
  `zsh-n.yml` check).
- Manually sourced the file with a stub `$ZI[cmd-list]` containing `version`
  and confirmed the `subcommands` pattern now matches `version`; with no
  `$ZI` set, confirmed the fallback list behaves exactly as before (no
  `version`, `load` etc. still match).

Fixes #51
