### PR TITLE
fix(completion): hide internal highlighting helpers

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -92,11 +92,11 @@ _zsh_highlight() {
   # Reset region highlight to build it from scratch
   # may need to remove path_prefix highlighting when the line ends
   if [[ $WIDGET == zle-line-finish ]] || _zsh_highlight_buffer_modified; then
-    -fast-highlight-init
-    -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    _fsh_highlight_init
+    _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
     (( FAST_HIGHLIGHT[use_brackets] )) && {
       _FAST_MAIN_CACHE=( $reply )
-      -fast-highlight-string-process "$PREBUFFER" "$BUFFER"
+      _fsh_highlight_string_process "$PREBUFFER" "$BUFFER"
     }
     region_highlight=( $reply )
   else
@@ -105,7 +105,7 @@ _zsh_highlight() {
       FAST_HIGHLIGHT[prev_char]="$char"
       (( FAST_HIGHLIGHT[use_brackets] )) && {
         reply=( $_FAST_MAIN_CACHE )
-        -fast-highlight-string-process "$PREBUFFER" "$BUFFER"
+        _fsh_highlight_string_process "$PREBUFFER" "$BUFFER"
         region_highlight=( $reply )
       }
     fi
@@ -392,7 +392,7 @@ zstyle -s :plugin:fast-syntax-highlighting theme __fsyh_theme
 
 unset __fsyh_theme
 
--fast-highlight-fill-option-variables
+_fsh_highlight_fill_option_variables
 
 if [[ ! -e $FAST_WORK_DIR/secondary_theme.zsh ]] {
   local theme_link=https://raw.githubusercontent.com/z-shell/F-Sy-H/main/share/free_theme.zsh

--- a/chroma/-sh.ch
+++ b/chroma/-sh.ch
@@ -50,7 +50,7 @@ local -a __lines_list
 
             FAST_HIGHLIGHT[chrome-git-got-c]=0
             (( _start_pos-__PBUFLEN >= 0 )) && \
-                -fast-highlight-process "$PREBUFFER" "${__wrd}" "$(( __start_pos + __idx2 - 1 ))"
+                _fsh_highlight_process "$PREBUFFER" "${__wrd}" "$(( __start_pos + __idx2 - 1 ))"
         elif [[ $__wrd = -*c* ]]; then
             FAST_HIGHLIGHT[chrome-git-got-c]=1
         else

--- a/chroma/-zi.ch
+++ b/chroma/-zi.ch
@@ -197,7 +197,7 @@ fsh__zi__chroma__def=(
 )
 
 #chroma/-zi-first-call() {
-    # This is being done in the proper place - in -fast-highlight-process
+    # This is being done in the proper place - in _fsh_highlight_process
     #FAST_HIGHLIGHT[chroma-zi-ice-elements-svn]=0
 #}
 
@@ -342,7 +342,7 @@ chroma/-zi-check-ice-mod() {
     if [[ "$_wrd" = (#b)(${(~j:|:)${ice_order[@]:#(${(~j:|:)nval_ices[@]:#(${(~j:|:)ext_val_ices[@]})})}})(*) ]]; then
         reply+=("$(( __start )) $(( __start+${mend[1]} )) ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-hyphen-option]}")
         reply+=("$(( __start+${mbegin[2]} )) $(( __end )) ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}optarg-string]}")
-        -fast-highlight-string
+        _fsh_highlight_string
         return 0
     elif [[ "$_wrd" = (#b)(${(~j:|:)nval_ices[@]}) ]]; then
         __style=${FAST_THEME_NAME}single-hyphen-option

--- a/functions/fast-highlight
+++ b/functions/fast-highlight
@@ -296,7 +296,7 @@ typeset -ga ZLAST_COMMANDS
 # Takes a single argument.
 #
 # The result will be stored in REPLY.
--fast-highlight-main-type() {
+_fsh_highlight_main_type() {
   REPLY=$__fast_highlight_main__command_type_cache[(e)$1]
   [[ -z $REPLY ]] && {
     if zmodload -e zsh/parameter; then
@@ -340,7 +340,7 @@ typeset -ga ZLAST_COMMANDS
 
 # Below are variables that must be defined in outer
 # scope so that they are reachable in *-process()
--fast-highlight-fill-option-variables() {
+_fsh_highlight_fill_option_variables() {
   if [[ -o ignore_braces ]] || eval '[[ -o ignore_close_braces ]] 2>/dev/null'; then
     FAST_HIGHLIGHT[right_brace_is_recognised_everywhere]=0
   else
@@ -369,7 +369,7 @@ typeset -ga ZLAST_COMMANDS
 
 
 # Main syntax highlighting function.
--fast-highlight-process() {
+_fsh_highlight_process() {
   builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob bare_glob_qual no_nomatch typeset_silent
 
@@ -451,7 +451,7 @@ typeset -ga ZLAST_COMMANDS
 
   [[ -n $ZCALC_ACTIVE ]] && {
     _start_pos=0; _end_pos=__len; __arg=$__buf
-    -fast-highlight-math-string
+    _fsh_highlight_math_string
     return 0
   }
 
@@ -626,12 +626,12 @@ typeset -ga ZLAST_COMMANDS
             $_mybuf = (#b)(*)(*)\$\{([a-zA-Z_][a-zA-Z0-9_:-]#|[0-9]##)(*) ]] && \
               (( ${+parameters[${match[3]%%:-*}]} ))
       then
-        -fast-highlight-main-type ${match[1]}${match[2]}${(P)match[3]%%:-*}${match[4]#\}}
+        _fsh_highlight_main_type ${match[1]}${match[2]}${(P)match[3]%%:-*}${match[4]#\}}
       elif [[ $braces_stack = T* ]]; then # T - typedef, etc.
         REPLY=none
       else
         : ${expanded_path::=${~_mybuf}}
-        -fast-highlight-main-type $expanded_path
+        _fsh_highlight_main_type $expanded_path
       fi
 
       case $REPLY in
@@ -710,7 +710,7 @@ typeset -ga ZLAST_COMMANDS
             (( itmp < iitmp && itmp <= __asize - 1 )) && (( jtmp > __asize && (jtmp = __asize), 1 > 0 )) && \
             (( __start=_start_pos-__PBUFLEN+itmp, __end=_start_pos-__PBUFLEN+jtmp, __start >= 0 )) && \
             reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}") && \
-            { itmp=${__arg[(i)=]}; __arg=${__arg[itmp,__asize]}; (( _start_pos += itmp - 1 )); -fast-highlight-string; \
+            { itmp=${__arg[(i)=]}; __arg=${__arg[itmp,__asize]}; (( _start_pos += itmp - 1 )); _fsh_highlight_string; \
             (( _start_pos = _start_pos - itmp + 1, 1 > 0 )); } || \
             { (( iitmp <= __asize - 1 )) && (( jjtmp > __asize && (jjtmp = __asize), 1 > 0 )) && \
             (( __start=_start_pos-__PBUFLEN+iitmp, __end=_start_pos-__PBUFLEN+jjtmp, __start >= 0 )) && \
@@ -718,7 +718,7 @@ typeset -ga ZLAST_COMMANDS
             } || {
               itmp=${__arg[(i)=]}; __arg=${__arg[itmp,__asize]}; (( _start_pos += itmp - 1 ));
               [[ ${__arg[2,4]} = '$((' ]] && {
-                -fast-highlight-math-string; (( __start=_start_pos-__PBUFLEN+2, __end=__start+2, __start >= 0 )) && \
+                _fsh_highlight_math_string; (( __start=_start_pos-__PBUFLEN+2, __end=__start+2, __start >= 0 )) && \
                 reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-paren]}")
                 # Counting complex brackets (for brackets-highlighter): 4. $(( in assign argument
                 _FAST_COMPLEX_BRACKETS+=( $__start $(( __start + 1 )) )
@@ -727,7 +727,7 @@ typeset -ga ZLAST_COMMANDS
                   # Counting complex brackets (for brackets-highlighter): 5. )) in assign argument
                   _FAST_COMPLEX_BRACKETS+=( $__start $(( __start + 1 )) )
                 }
-              } || -fast-highlight-string; (( _start_pos = _start_pos - itmp + 1, 1 > 0 ))
+              } || _fsh_highlight_string; (( _start_pos = _start_pos - itmp + 1, 1 > 0 ))
             }
           } elif [[ $__arg = ${histchars[1]}* && -n ${__arg[2]} ]] {
             __style=${FAST_THEME_NAME}history-expansion
@@ -758,7 +758,7 @@ typeset -ga ZLAST_COMMANDS
 
             # Counting complex brackets (for brackets-highlighter): 6. (( as command
             _FAST_COMPLEX_BRACKETS+=( $__start $(( __start + 1 )) )
-            -fast-highlight-math-string
+            _fsh_highlight_math_string
 
             # ADD
             [[ $__arg[-2,-1] == '))' ]] && {
@@ -866,7 +866,7 @@ typeset -ga ZLAST_COMMANDS
         '-'*)    (( !_was_double_hyphen )) && __style=${FAST_THEME_NAME}single-hyphen-option || __style=${FAST_THEME_NAME}default;;
         \$\'*)
                  (( __start=_start_pos-__PBUFLEN, __end=_end_pos-__PBUFLEN, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}dollar-quoted-argument]}")
-                 -fast-highlight-dollar-string
+                 _fsh_highlight_dollar_string
                  already_added=1
                  ;;
         [\"\']*|[^\"\\]##([\\][\\])#\"*|[^\'\\]##([\\][\\])#\'*)
@@ -883,7 +883,7 @@ typeset -ga ZLAST_COMMANDS
                      __idx=0
                    fi
                    (( _start_pos-__PBUFLEN >= 0 )) && \
-                     -fast-highlight-process "$PREBUFFER" "${${__arg%[\'\"]}#[\'\"]}" $(( _start_pos + 1 ))
+                     _fsh_highlight_process "$PREBUFFER" "${${__arg%[\'\"]}#[\'\"]}" $(( _start_pos + 1 ))
                    (( __idx )) && FAST_THEME_NAME=$_mybuf
                    already_added=1
                  else
@@ -911,7 +911,7 @@ typeset -ga ZLAST_COMMANDS
                            [[ $__tmp = \" ]] && {
                              __arg=${cdpath_dir[iitmp+1,itmp-1]}
                              (( _start_pos += iitmp - 1 + 1 ))
-                             -fast-highlight-string
+                             _fsh_highlight_string
                              (( _start_pos = _start_pos - iitmp + 1 - 1 ))
                            }
                            # The end-of-quoting proper algorithm action
@@ -932,7 +932,7 @@ typeset -ga ZLAST_COMMANDS
                      [[ $__tmp = \" ]] && {
                        __arg=${cdpath_dir[iitmp+1,__asize]}
                        (( _start_pos += iitmp - 1 + 1 ))
-                       -fast-highlight-string
+                       _fsh_highlight_string
                        (( _start_pos = _start_pos - iitmp + 1 - 1 ))
                      }
                    }
@@ -940,7 +940,7 @@ typeset -ga ZLAST_COMMANDS
                  ;;
         \$\(\(*)
                  already_added=1
-                 -fast-highlight-math-string
+                 _fsh_highlight_math_string
                  # ADD
                  (( __start=_start_pos-__PBUFLEN+1, __end=__start+2, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-paren]}")
                  # Counting complex brackets (for brackets-highlighter): 9. $(( as argument
@@ -962,7 +962,7 @@ typeset -ga ZLAST_COMMANDS
                    __idx=0
                  fi
                  (( _start_pos-__PBUFLEN >= 0 )) && \
-                   -fast-highlight-process "$PREBUFFER" "${${__arg%[\`]}#[\`]}" $(( _start_pos + 1 ))
+                   _fsh_highlight_process "$PREBUFFER" "${${__arg%[\`]}#[\`]}" $(( _start_pos + 1 ))
                  (( __idx )) && FAST_THEME_NAME=$_mybuf
                  already_added=1
           ;;
@@ -993,7 +993,7 @@ typeset -ga ZLAST_COMMANDS
                  ;;
         *)       # F - (( after for
                  if [[ $braces_stack = F* ]]; then
-                   -fast-highlight-string
+                   _fsh_highlight_string
                    _mybuf=$__arg
                    __idx=_start_pos
                    while [[ $_mybuf = (#b)[^a-zA-Z\{\$]#([a-zA-Z][a-zA-Z0-9]#)(*) ]]; do
@@ -1056,7 +1056,7 @@ typeset -ga ZLAST_COMMANDS
                  else
                    if [[ ${FAST_HIGHLIGHT[no_check_paths]} != 1 ]]; then
                      if [[ ${FAST_HIGHLIGHT[use_async]} != 1 ]]; then
-		       if -fast-highlight-check-path noasync; then
+                       if _fsh_highlight_check_path noasync; then
 			 # ADD
 			 (( __start=_start_pos-__PBUFLEN, __end=_end_pos-__PBUFLEN, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[$__style]}")
                          already_added=1
@@ -1074,7 +1074,7 @@ typeset -ga ZLAST_COMMANDS
 		     else
 		       if [[ -z ${FAST_HIGHLIGHT[cache-path-${(q)__arg}-${_start_pos}]} || $(( EPOCHSECONDS - FAST_HIGHLIGHT[cache-path-${(q)__arg}-${_start_pos}-born-at] )) -gt 8 ]]; then
 			 if [[ $LASTWIDGET != *-or-beginning-search ]]; then
-			   exec {PCFD}< <(-fast-highlight-check-path; sleep 5)
+                           exec {PCFD}< <(_fsh_highlight_check_path; sleep 5)
 			   command sleep 0
 			   FAST_HIGHLIGHT[path-queue]+=";$_start_pos $_end_pos;"
 			   is-at-least 5.0.6 && __pos=1 || __pos=0
@@ -1100,7 +1100,7 @@ typeset -ga ZLAST_COMMANDS
     then
       (( next_word = (next_word | 2) & ~129 ))
       [[ ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}here-string-text]} != "none" ]] && (( __start=_start_pos-__PBUFLEN, __end=_end_pos-__PBUFLEN, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}here-string-text]}")
-      -fast-highlight-string ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}here-string-var]:#none}
+      _fsh_highlight_string ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}here-string-var]:#none}
       already_added=1
     elif (( this_word & (BIT_case_preamble + BIT_case_item) ))
     then
@@ -1238,7 +1238,7 @@ typeset -ga ZLAST_COMMANDS
       (( __start=${_mybuf%%;*}-__PBUFLEN-1, __end=${_mybuf##*;}-__PBUFLEN, __start >= 0 )) && \
         reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${__tmp}recursive-base]}")
       # Pass authentic buffer for recursive analysis
-      -fast-highlight-process "$PREBUFFER" "${__buf[${_mybuf%%;*},${_mybuf##*;}]}" $(( ${_mybuf%%;*} - 1 ))
+      _fsh_highlight_process "$PREBUFFER" "${__buf[${_mybuf%%;*},${_mybuf##*;}]}" $(( ${_mybuf%%;*} - 1 ))
     done
     # Restore theme
     (( __idx )) && FAST_THEME_NAME=$__tmp
@@ -1247,7 +1247,7 @@ typeset -ga ZLAST_COMMANDS
   return 0
 }
 
--fast-highlight-check-path() {
+_fsh_highlight_check_path() {
   (( _start_pos-__PBUFLEN >= 0 )) || \
     { [[ $1 != "noasync" ]] && print -r -- "- $_start_pos $_end_pos"; return 1; }
   [[ $1 != "noasync" ]] && {
@@ -1274,7 +1274,7 @@ typeset -ga ZLAST_COMMANDS
   return 1
 }
 
--fast-highlight-check-path-handler() {
+_fsh_highlight_check_path_handler() {
   local IFS=$'\n' pid PCFD=$1 line stripped val
   integer idx
 
@@ -1305,7 +1305,7 @@ typeset -ga ZLAST_COMMANDS
   exec {PCFD}<&-
 }
 
-zle -N -- fast-highlight-check-path-handler -fast-highlight-check-path-handler
+zle -N -- fast-highlight-check-path-handler _fsh_highlight_check_path_handler
 
 # Highlight special blocks inside double-quoted strings
 #
@@ -1320,7 +1320,7 @@ zle -N -- fast-highlight-check-path-handler -fast-highlight-check-path-handler
 # backslash-something (not ['"$]) is occurred.
 #
 # $1 - additional style to glue-in to added style
--fast-highlight-string() {
+_fsh_highlight_string() {
   (( _start_pos-__PBUFLEN >= 0 )) || return 0
   _mybuf=$__arg
   __idx=_start_pos
@@ -1355,7 +1355,7 @@ zle -N -- fast-highlight-check-path-handler -fast-highlight-check-path-handler
 # - D matches words [a-zA-Z]## (variables)
 #
 # Parameters used: _mybuf, __idx, _end_idx, __style
--fast-highlight-math-string() {
+_fsh_highlight_math_string() {
   (( _start_pos-__PBUFLEN >= 0 )) || return 0
   _mybuf=$__arg
   __idx=_start_pos
@@ -1391,7 +1391,7 @@ zle -N -- fast-highlight-check-path-handler -fast-highlight-check-path-handler
 }
 
 # Highlight special chars inside dollar-quoted strings
--fast-highlight-dollar-string() {
+_fsh_highlight_dollar_string() {
   (( _start_pos-__PBUFLEN >= 0 )) || return 0
   local i j k __style
   local AA
@@ -1433,14 +1433,14 @@ zle -N -- fast-highlight-check-path-handler -fast-highlight-check-path-handler
   done
 }
 
--fast-highlight-init() {
+_fsh_highlight_init() {
   _FAST_COMPLEX_BRACKETS=()
   __fast_highlight_main__command_type_cache=()
 }
 
 typeset -ga FSH_LIST
--fsh_sy_h_shappend() {
+_fsh_shappend() {
   FSH_LIST+=( "$(( $1 - 1 ));;$(( $2 ))" )
 }
 
-functions -M fsh_sy_h_append 2 2 -fsh_sy_h_shappend 2>/dev/null
+functions -M fsh_sy_h_append 2 2 _fsh_shappend 2>/dev/null

--- a/functions/fast-string-highlight
+++ b/functions/fast-string-highlight
@@ -6,7 +6,7 @@
 # $1 - PREBUFFER
 # $2 - BUFFER
 #
--fast-highlight-string-process() {
+_fsh_highlight_string_process() {
   builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob typeset_silent no_short_loops rc_quotes no_auto_pushd
 

--- a/scripts/test-function-completion.zsh
+++ b/scripts/test-function-completion.zsh
@@ -25,15 +25,15 @@ function _fsh_test_read_until() {
   builtin emulate -L zsh
 
   local pattern=$1 chunk
-  integer attempt=0
+  integer read_deadline=$(( SECONDS + 30 ))
   REPLY=
 
-  while (( ++attempt <= 500 )); do
+  while (( SECONDS < read_deadline )); do
     if zpty -r -t "$pty_name" chunk; then
       REPLY+=$chunk
       [[ $REPLY == ${~pattern} ]] && return 0
     else
-      command sleep 0.01
+      command sleep 0.02
     fi
   done
 
@@ -42,10 +42,14 @@ function _fsh_test_read_until() {
 
 {
   : >| "$test_dir/secondary_theme.zsh" || _fsh_test_fail 'cannot prepare isolated theme cache'
+  command mkdir -p -- "$test_dir/home" "$test_dir/zdotdir" || \
+    _fsh_test_fail 'cannot prepare isolated shell directories'
   zmodload zsh/zpty || _fsh_test_fail 'zsh/zpty is unavailable'
 
   if (( test_status == 0 )); then
-    zpty -b "$pty_name" zsh -f || _fsh_test_fail 'cannot start isolated interactive Zsh'
+    zpty -b "$pty_name" \
+      "HOME=${(q)test_dir}/home ZDOTDIR=${(q)test_dir}/zdotdir zsh -f" || \
+      _fsh_test_fail 'cannot start isolated interactive Zsh'
   fi
 
   if (( test_status == 0 )); then
@@ -54,8 +58,9 @@ function _fsh_test_read_until() {
   fi
 
   if (( test_status == 0 )); then
-    zpty -w "$pty_name" "FAST_WORK_DIR=${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
-    _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]*' || _fsh_test_fail 'F-Sy-H did not load in the interactive Zsh'
+    zpty -w "$pty_name" "FAST_WORK_DIR=${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D; PS1='FSH_INTERRUPT_READY> '; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
+    _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]*FSH_INTERRUPT_READY*' || \
+      _fsh_test_fail "F-Sy-H did not load in the interactive Zsh: ${(V)REPLY[1,1000]}"
     load_output=$REPLY
   fi
 
@@ -63,9 +68,8 @@ function _fsh_test_read_until() {
     zpty -w -n "$pty_name" $'time -\t'
     command sleep 0.1
     zpty -w -n "$pty_name" $'\C-C'
-    command sleep 0.1
-    zpty -w "$pty_name" 'print -r -- FSH_${:-COMPLETION}_DONE'
-    _fsh_test_read_until '*FSH_COMPLETION_DONE*' || _fsh_test_fail 'completion probe did not finish'
+    _fsh_test_read_until '*FSH_INTERRUPT_READY*' || \
+      _fsh_test_fail "completion probe did not return to the prompt: ${(V)REPLY[1,1000]}"
     completion_output=$REPLY
   fi
 

--- a/scripts/test-function-completion.zsh
+++ b/scripts/test-function-completion.zsh
@@ -1,0 +1,81 @@
+#!/usr/bin/env zsh
+
+builtin emulate -R zsh
+builtin setopt pipe_fail
+
+typeset -r plugin_path=${1:-${0:a:h:h}/F-Sy-H.plugin.zsh}
+[[ -r $plugin_path ]] || {
+  builtin print -u2 -r -- "plugin is not readable: $plugin_path"
+  exit 1
+}
+
+typeset test_dir
+test_dir=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-completion.XXXXXX") || exit 1
+
+typeset -r pty_name=fsyh-completion
+typeset load_output completion_output REPLY
+integer test_status=0
+
+function _fsh_test_fail() {
+  builtin print -u2 -r -- "$1"
+  test_status=1
+}
+
+function _fsh_test_read_until() {
+  builtin emulate -L zsh
+
+  local pattern=$1 chunk
+  integer attempt=0
+  REPLY=
+
+  while (( ++attempt <= 500 )); do
+    if zpty -r -t "$pty_name" chunk; then
+      REPLY+=$chunk
+      [[ $REPLY == ${~pattern} ]] && return 0
+    else
+      command sleep 0.01
+    fi
+  done
+
+  return 1
+}
+
+{
+  : >| "$test_dir/secondary_theme.zsh" || _fsh_test_fail 'cannot prepare isolated theme cache'
+  zmodload zsh/zpty || _fsh_test_fail 'zsh/zpty is unavailable'
+
+  if (( test_status == 0 )); then
+    zpty -b "$pty_name" zsh -f || _fsh_test_fail 'cannot start isolated interactive Zsh'
+  fi
+
+  if (( test_status == 0 )); then
+    zpty -w "$pty_name" "PS1=''; unsetopt prompt_cr prompt_sp; print -r -- FSH_\${:-READY}_DONE"
+    _fsh_test_read_until '*FSH_READY_DONE*' || _fsh_test_fail 'interactive Zsh did not become ready'
+  fi
+
+  if (( test_status == 0 )); then
+    zpty -w "$pty_name" "FAST_WORK_DIR=${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
+    _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]*' || _fsh_test_fail 'F-Sy-H did not load in the interactive Zsh'
+    load_output=$REPLY
+  fi
+
+  if (( test_status == 0 )); then
+    zpty -w -n "$pty_name" $'time -\t'
+    command sleep 0.1
+    zpty -w -n "$pty_name" $'\C-C'
+    command sleep 0.1
+    zpty -w "$pty_name" 'print -r -- FSH_${:-COMPLETION}_DONE'
+    _fsh_test_read_until '*FSH_COMPLETION_DONE*' || _fsh_test_fail 'completion probe did not finish'
+    completion_output=$REPLY
+  fi
+
+  [[ $load_output == *FSH_LOAD_NEW:1:OLD:0* ]] || \
+    _fsh_test_fail 'plugin did not expose only the private _fsh helper namespace'
+  [[ $completion_output != *-fast-highlight* && $completion_output != *-fsh_sy_h* ]] || \
+    _fsh_test_fail 'dash-prefixed F-Sy-H functions leaked into time completion'
+} always {
+  (( ${+builtins[zpty]} )) && zpty -d "$pty_name" 2>/dev/null
+  command rm -rf -- "$test_dir"
+}
+
+exit "$test_status"

--- a/scripts/test-function-completion.zsh
+++ b/scripts/test-function-completion.zsh
@@ -58,7 +58,7 @@ function _fsh_test_read_until() {
   fi
 
   if (( test_status == 0 )); then
-    zpty -w "$pty_name" "FAST_WORK_DIR=${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D; PS1='FSH_INTERRUPT_READY> '; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
+    zpty -w "$pty_name" "FAST_WORK_DIR=${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D -i; PS1='FSH_INTERRUPT_READY> '; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
     _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]*FSH_INTERRUPT_READY*' || \
       _fsh_test_fail "F-Sy-H did not load in the interactive Zsh: ${(V)REPLY[1,1000]}"
     load_output=$REPLY

--- a/share/parse/parse.zsh
+++ b/share/parse/parse.zsh
@@ -157,15 +157,15 @@ for (( i = 0; i <= 2; ++ i )) { print \$i; }
 
   local right_brace_is_recognised_everywhere
   integer path_dirs_was_set multi_func_def ointeractive_comments
-  -fast-highlight-fill-option-variables
+  _fsh_highlight_fill_option_variables
 
   local BUFFER
   for BUFFER in "${long_input[@]}"; do
     reply=( )
     () {
-      -fast-highlight-init
-      -fast-highlight-process "" "$BUFFER" "0"
-      -fast-highlight-string-process "" "$BUFFER"
+      _fsh_highlight_init
+      _fsh_highlight_process "" "$BUFFER" "0"
+      _fsh_highlight_string_process "" "$BUFFER"
     }
   done
 
@@ -180,15 +180,15 @@ elif [[ -r "$1" ]]; then
   SECONDS=0
 
   reply=( )
-  -fast-highlight-init
+  _fsh_highlight_init
 
   local right_brace_is_recognised_everywhere
   integer path_dirs_was_set multi_func_def ointeractive_comments
-  -fast-highlight-fill-option-variables
+  _fsh_highlight_fill_option_variables
 
   () {
-    -fast-highlight-process "" "$BUFFER" "0"
-    -fast-highlight-string-process "" "$BUFFER"
+    _fsh_highlight_process "" "$BUFFER" "0"
+    _fsh_highlight_string_process "" "$BUFFER"
   }
 
   print "Running time: $SECONDS"

--- a/tests/main.zunit
+++ b/tests/main.zunit
@@ -2,14 +2,14 @@
 @setup {
     load "../functions/fast-highlight"
     setopt interactive_comments
-    -fast-highlight-fill-option-variables
+    _fsh_highlight_fill_option_variables
 }
 
 @test 'ls /usr/bin' {
 reply=()
     PREBUFFER=""
     BUFFER="ls /usr/bin"
-    evl -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    evl _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 
     assert "$reply[1]" same_as "0 2 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}command]}"
     assert "$reply[2]" same_as "3 11 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}path-to-dir]}"
@@ -20,7 +20,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER="ls /bin/df"
-    evl -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    evl _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 
     assert "$reply[1]" same_as "0 2 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}command]}"
     assert "$reply[2]" same_as "3 10 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}path]}"
@@ -32,7 +32,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER=$'ls /bin/df\n # a comment\nls /usr/bin'
-    evl -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    evl _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 
     assert "$reply[1]" same_as "0 2 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}command]}"
     assert "$reply[2]" same_as "3 10 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}path]}"
@@ -47,7 +47,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER=$'exec {FD}< <( ls /bin )'
-    evl -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    evl _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 
     assert "$reply[1]" same_as "0 4 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}precommand]}"
     assert "$reply[2]" same_as "5 9 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}exec-descriptor]}"
@@ -59,7 +59,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER=$'case x in\nx) a;;\n(y)\n;;\nesac'
-    evl -fast-highlight-process "$PREBUFFER" "$BUFFER" 0
+    evl _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 
     assert "$reply[1]" same_as "0 4 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}reserved-word]}"
     assert "$reply[2]" same_as "5 6 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}case-input]}"
@@ -74,17 +74,17 @@ reply=()
     assert "$reply[11]" same_as ""
 }
 
-@test '-fast-highlight-process "$PREBUFFER" "$BUFFER" 0' {
+@test '_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0' {
     reply=()
     PREBUFFER=""
-    BUFFER='-fast-highlight-process "$PREBUFFER" "$BUFFER" 0'
-    evl -fast-highlight-process "\$PREBUFFER" "\$BUFFER" 0
+    BUFFER='_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0'
+    evl _fsh_highlight_process "\$PREBUFFER" "\$BUFFER" 0
 
-    assert "$reply[1]" same_as "0 23 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}function]}"
-    assert "$reply[2]" same_as "24 36 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}"
-    assert "$reply[3]" same_as "25 35 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}back-or-dollar-double-quoted-argument]}"
-    assert "$reply[4]" same_as "37 46 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}"
-    assert "$reply[5]" same_as "38 45 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}back-or-dollar-double-quoted-argument]}"
+    assert "$reply[1]" same_as "0 22 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}function]}"
+    assert "$reply[2]" same_as "23 35 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}"
+    assert "$reply[3]" same_as "24 34 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}back-or-dollar-double-quoted-argument]}"
+    assert "$reply[4]" same_as "36 45 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-quoted-argument]}"
+    assert "$reply[5]" same_as "37 44 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}back-or-dollar-double-quoted-argument]}"
     assert "$reply[6]" same_as ""
 }
 
@@ -92,7 +92,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER='command tr : \\n <<<test$PATH'
-    evl -fast-highlight-process "\$PREBUFFER" "\$BUFFER" 0
+    evl _fsh_highlight_process "\$PREBUFFER" "\$BUFFER" 0
 
     assert "$reply[1]" same_as "0 7 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}precommand]}"
     assert "$reply[2]" same_as "8 10 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}command]}"
@@ -107,7 +107,7 @@ reply=()
     reply=()
     PREBUFFER=""
     BUFFER='local var1; (( var + var1 + $var + $var1 + 123 ))'
-    evl -fast-highlight-process "\$PREBUFFER" "\$BUFFER" 0
+    evl _fsh_highlight_process "\$PREBUFFER" "\$BUFFER" 0
 
     # Should actually be `reserved-word', but the type -w call returns `builtin'…
     assert "$reply[1]" same_as "0 5 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}builtin]}"
@@ -119,4 +119,11 @@ reply=()
     assert "$reply[7]" same_as "43 46 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}mathnum]}"
     assert "$reply[8]" same_as "47 49 ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}double-paren]}"
     assert "$reply[9]" same_as ""
+}
+
+@test 'private functions do not pollute dash completion' {
+    run zsh -f ./scripts/test-function-completion.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
 }


### PR DESCRIPTION
## Summary

- rename internal highlighting helpers into the private `_fsh_*` namespace
- update all plugin, parser, chroma, and test call sites consistently
- add a PTY regression test proving `time -<Tab>` no longer exposes dash-prefixed F-Sy-H helpers

## Verification

- `zsh -f scripts/test-function-completion.zsh`
- negative control against the untouched base reproduces the leak
- ZUnit 0.8.2: 9/9 tests passed on Zsh 5.9.2
- native `zsh -f -n` syntax sweep passed
- native `zcompile -U -z` sweep passed
- `git diff --check` passed

## Scope

This fixes the completion leak only. Broader Zsh Plugin Standard 2 migration remains separate work.

Fixes #35
