### PR TITLE
fix(chroma): isolate git preprocessing results

### DIFF
--- a/chroma/main-chroma.ch
+++ b/chroma/main-chroma.ch
@@ -320,7 +320,8 @@ chroma/main-process-token.ch() {
 # fields in the fsh__${__chroma_name}__chroma__def hash
 chroma/-pre_process_chroma_def.ch() {
   local __key __value __ke _val __the_hash_name="$1" __var_name
-  local -a __split
+  # Keep callback results separate from the caller's highlight accumulator.
+  local -a __split reply
 
   chroma/main-chroma-print -rl -- "Starting PRE_PROCESS for __the_hash_name:$__the_hash_name"
 

--- a/scripts/test-git-chroma-regions.zsh
+++ b/scripts/test-git-chroma-regions.zsh
@@ -1,0 +1,72 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+
+typeset -r plugin_root=${0:A:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-git-chroma.XXXXXXXX")
+typeset -r reported_buffer='(cd ../dir; git diff)|patch -p1'
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+typeset -gx FAST_WORK_DIR=$fixture_root/work
+command mkdir -p -- "$ZDOTDIR"
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+
+assert_region_contract() {
+  emulate -L zsh
+  setopt extended_glob
+
+  local entry
+  local -a fields
+
+  (( ${#region_highlight} > 0 )) || {
+    builtin print -u2 -r -- 'git chroma produced no highlight regions'
+    return 1
+  }
+
+  for entry in "${region_highlight[@]}"; do
+    fields=( ${(z)entry} )
+    (( ${#fields} >= 3 )) || {
+      builtin print -u2 -r -- "malformed region_highlight entry: ${(qqq)entry}"
+      return 1
+    }
+    [[ ${fields[1]} == <-> && ${fields[2]} == <-> ]] || {
+      builtin print -u2 -r -- "non-numeric region_highlight offsets: ${(qqq)entry}"
+      return 1
+    }
+    (( fields[1] <= fields[2] && fields[2] <= ${#BUFFER} )) || {
+      builtin print -u2 -r -- "out-of-range region_highlight entry: ${(qqq)entry}"
+      return 1
+    }
+  done
+
+  return 0
+}
+
+highlight_and_assert() {
+  emulate -L zsh
+
+  local expected_buffer=$1
+
+  typeset -g BUFFER=$expected_buffer PREBUFFER= WIDGET=self-insert
+  typeset -gi CURSOR=${#BUFFER} PENDING=0 REGION_ACTIVE=0
+  typeset -gi YANK_ACTIVE=0 ISEARCHMATCH_ACTIVE=0 SUFFIX_ACTIVE=0
+  typeset -ga region_highlight=()
+
+  # The highlighter preserves the status of the command that invoked it.
+  builtin true
+  _zsh_highlight || {
+    builtin print -u2 -r -- 'git chroma highlighter returned a failure status'
+    return 1
+  }
+
+  [[ $BUFFER == "$expected_buffer" ]] || {
+    builtin print -u2 -r -- 'git chroma changed the command buffer'
+    return 1
+  }
+  assert_region_contract
+}
+
+highlight_and_assert "$reported_buffer" || exit $?

--- a/tests/main.zunit
+++ b/tests/main.zunit
@@ -148,3 +148,10 @@ reply=()
     assert "$output" is_empty
     assert "$state" same_as "0"
 }
+
+@test 'git chroma preserves region_highlight contract on first use' {
+    run zsh -f ./scripts/test-git-chroma-regions.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}


### PR DESCRIPTION
## Summary

- isolate Git chroma preprocessing callback results from the highlighter's range accumulator
- add a regression for the exact first-use subshell command reported in issue #44
- verify every generated `region_highlight` entry has valid numeric offsets

## Root cause

The Git subcommand callback writes its result through the dynamically scoped `reply` array. During first-use chroma preprocessing, that name resolved to `_zsh_highlight`'s range accumulator, so Git subcommand names were passed to ZLE as malformed highlight regions.

Localizing `reply` inside `chroma/-pre_process_chroma_def.ch` preserves the callback contract without leaking those values into `region_highlight`.

## Verification

- ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 13 passed, 0 failed
- standalone entrypoint, completion, and lifecycle tests passed
- native Zsh syntax validation passed for 51 source files
- Trunk: 14 of 14 checks passed
- `git diff --check` passed

Closes #44
