### PR TITLE
fix(chroma): accept directories for git commit

### DIFF
--- a/chroma/-git.ch
+++ b/chroma/-git.ch
@@ -145,7 +145,7 @@ fsh__git__chroma__def=(
     ##
     ## {{{
 
-    subcmd:commit "COMMIT_#_opt // FILE_#_arg // NO_MATCH_#_opt"
+    subcmd:commit "COMMIT_#_opt // COMMIT_FILE_OR_DIR_#_arg // NO_MATCH_#_opt"
 
     "COMMIT_#_opt" "
               (-m|--message=|-am)
@@ -163,7 +163,9 @@ fsh__git__chroma__def=(
                        <<>> NO-OP // ::chroma/main-chroma-std-aopt-action
                        <<>> NO-OP // ::chroma/main-chroma-std-aopt-ARG-action"
 
-    # A generic action
+    "COMMIT_FILE_OR_DIR_#_arg" "NO-OP // ::chroma/-git-verify-file-or-dir"
+
+    # A generic action shared by other subcommands
     "FILE_#_arg" "NO-OP // ::chroma/-git-verify-file"
 
     ## }}}

--- a/scripts/test-git-chroma-regions.zsh
+++ b/scripts/test-git-chroma-regions.zsh
@@ -4,15 +4,25 @@ emulate -R zsh
 
 typeset -r plugin_root=${0:A:h:h}
 typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-git-chroma.XXXXXXXX")
+typeset -r fixture_repo=$fixture_root/repo
 typeset -r reported_buffer='(cd ../dir; git diff)|patch -p1'
 trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
 
 typeset -gx ZDOTDIR=$fixture_root/zdotdir
 typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
 typeset -gx FAST_WORK_DIR=$fixture_root/work
-command mkdir -p -- "$ZDOTDIR"
+command mkdir -p -- \
+  "$ZDOTDIR" \
+  "$fixture_repo/some/folder/with/changes"
+command touch -- \
+  "$fixture_repo/some/file.lua" \
+  "$fixture_repo/some/folder/with/changes/changed.lua"
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
+builtin cd -- "$fixture_repo"
+
+FAST_HIGHLIGHT_STYLES[correct-subtle]=fg=green
+FAST_HIGHLIGHT_STYLES[incorrect-subtle]=fg=red
 
 assert_region_contract() {
   emulate -L zsh
@@ -69,4 +79,31 @@ highlight_and_assert() {
   assert_region_contract
 }
 
+assert_trailing_token_style() {
+  emulate -L zsh
+
+  local expected_buffer=$1 expected_style=$2
+  local token=${expected_buffer##* }
+  local entry
+  local -a fields
+  integer token_start=$(( ${#expected_buffer} - ${#token} ))
+
+  highlight_and_assert "$expected_buffer" || return
+
+  for entry in "${region_highlight[@]}"; do
+    fields=( ${(z)entry} )
+    if (( fields[1] == token_start && fields[2] == ${#expected_buffer} )) &&
+      [[ ${fields[3]} == "$expected_style" ]]; then
+      return 0
+    fi
+  done
+
+  builtin print -u2 -r -- \
+    "missing $expected_style region for trailing token in: $expected_buffer"
+  return 1
+}
+
 highlight_and_assert "$reported_buffer" || exit $?
+assert_trailing_token_style 'git commit some/file.lua' fg=green || exit $?
+assert_trailing_token_style 'git commit some/folder/with/changes/' fg=green || exit $?
+assert_trailing_token_style 'git commit missing/path/' fg=red || exit $?


### PR DESCRIPTION
## Type of changes

- [ ] CI
- [x] Bugfix
- [ ] Feature
- [ ] Generic maintenance tasks
- [ ] Documentation content changes
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no URL changes)
- [ ] Improving the performance of the project (not introducing new features)
- [ ] Other (please describe):

Issue Number: #37

## What is the current behavior?

Git chroma routes every positional argument to `git commit` through the
file-only verifier. Existing directory pathspecs are therefore highlighted
with `incorrect-subtle`, even though Git accepts them.

## What is the new behavior?

`git commit` uses a commit-specific argument route backed by the existing
file-or-directory verifier. Other Git subcommands retain the shared file-only
route.

The focused regression covers an existing file, an existing directory with a
file below it, and a missing path.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Verification

- `zsh -f scripts/test-git-chroma-regions.zsh`
- ZUnit 0.8.2: 13 tests passed on Zsh 5.9.2
- native `zsh -n` and `zcompile`: 45 files passed
- `git diff --check`
- `trunk check --filter=git-diff-check`

## Other information

Closes #37
