### PR TITLE
fix(chroma): preserve global alias highlighting

### DIFF
--- a/functions/fast-highlight
+++ b/functions/fast-highlight
@@ -387,6 +387,7 @@ _fsh_highlight_process() {
   # __idx and _end_idx are used in sub-functions
   # for this_word and next_word look below at commented integers and at state machine description
   integer __arg_type=0 MBEGIN MEND in_redirection __len=${#__buf} __PBUFLEN=${#1} already_added offset __idx _end_idx this_word=1 next_word=0 __pos  __asize __delimited=0 itmp iitmp
+  integer chroma_global_alias chroma_reply_count chroma_start_pos chroma_already_added chroma_status
   local -a match mbegin mend __inputs __list
 
   # This comment explains the numbers:
@@ -569,10 +570,23 @@ _fsh_highlight_process() {
       fi
    fi
 
-   (( this_word & 8192 )) && {
+   if (( this_word & 8192 )); then
      __list=( ${(z@)${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
-     ${${FAST_HIGHLIGHT[chroma-${__list[1]}]}%\%*} ${(M)FAST_HIGHLIGHT[chroma-${__list[1]}]%\%*} 0 "$__arg" $_start_pos $_end_pos 2>/dev/null && continue
-   }
+     (( chroma_global_alias = ${+galiases[(e)${(Q)__arg}]} ))
+     if (( chroma_global_alias )); then
+       # Preserve chroma parser state, but let the generic path style global aliases.
+       (( chroma_reply_count = ${#reply}, chroma_start_pos = _start_pos,
+          chroma_already_added = already_added ))
+     fi
+     ${${FAST_HIGHLIGHT[chroma-${__list[1]}]}%\%*} ${(M)FAST_HIGHLIGHT[chroma-${__list[1]}]%\%*} 0 "$__arg" $_start_pos $_end_pos 2>/dev/null
+     chroma_status=$?
+     if (( chroma_global_alias )); then
+       (( ${#reply} > chroma_reply_count )) && reply[$(( chroma_reply_count + 1 )),-1]=()
+       (( _start_pos = chroma_start_pos, already_added = chroma_already_added ))
+     elif (( chroma_status == 0 )); then
+       continue
+     fi
+   fi
 
    (( this_word & 1 )) && {
      # !in_redirection needed particularly for exec {A}>b {C}>d

--- a/scripts/test-git-chroma-regions.zsh
+++ b/scripts/test-git-chroma-regions.zsh
@@ -23,6 +23,9 @@ builtin cd -- "$fixture_repo"
 
 FAST_HIGHLIGHT_STYLES[correct-subtle]=fg=green
 FAST_HIGHLIGHT_STYLES[incorrect-subtle]=fg=red
+FAST_HIGHLIGHT_STYLES[global-alias]=fg=cyan
+alias -g NOOUT='>/dev/null'
+alias -g MESSAGE=subject
 
 assert_region_contract() {
   emulate -L zsh
@@ -86,24 +89,33 @@ assert_trailing_token_style() {
   local token=${expected_buffer##* }
   local entry
   local -a fields
+  integer matching_regions=0
   integer token_start=$(( ${#expected_buffer} - ${#token} ))
 
   highlight_and_assert "$expected_buffer" || return
 
   for entry in "${region_highlight[@]}"; do
     fields=( ${(z)entry} )
-    if (( fields[1] == token_start && fields[2] == ${#expected_buffer} )) &&
-      [[ ${fields[3]} == "$expected_style" ]]; then
-      return 0
-    fi
+    (( fields[1] == token_start && fields[2] == ${#expected_buffer} )) || continue
+    (( ++matching_regions ))
+    [[ ${fields[3]} == "$expected_style" ]] || {
+      builtin print -u2 -r -- \
+        "unexpected ${fields[3]} region for trailing token in: $expected_buffer"
+      return 1
+    }
   done
 
-  builtin print -u2 -r -- \
-    "missing $expected_style region for trailing token in: $expected_buffer"
-  return 1
+  (( matching_regions == 1 )) || {
+    builtin print -u2 -r -- \
+      "expected one $expected_style region for trailing token in: $expected_buffer"
+    return 1
+  }
 }
 
 highlight_and_assert "$reported_buffer" || exit $?
 assert_trailing_token_style 'git commit some/file.lua' fg=green || exit $?
 assert_trailing_token_style 'git commit some/folder/with/changes/' fg=green || exit $?
 assert_trailing_token_style 'git commit missing/path/' fg=red || exit $?
+assert_trailing_token_style 'git commit --dry-run NOOUT' fg=cyan || exit $?
+assert_trailing_token_style 'git commit --dry-run NOOUT missing/path/' fg=red || exit $?
+assert_trailing_token_style 'git commit -m MESSAGE missing/path/' fg=red || exit $?


### PR DESCRIPTION
# Pull request template

## Type of changes

- [ ] CI
- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Issue Number: #38

## What is the current behavior?

Command-specific chromas validate global-alias tokens as literal command arguments. Git chroma therefore colors aliases such as `NOOUT` with `incorrect-subtle` instead of the configured global-alias style.

## What is the new behavior?

Global-alias tokens still advance command-chroma parser state, but chroma-specific visual regions for those tokens are discarded so the generic highlighter applies the global-alias style. This preserves pending option arguments and following-token validation.

The focused regression covers the reported alias, rejects overlapping full-token styles, verifies a following Git path remains validated, and covers a global alias used as a pending `-m` argument.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Verification

- `zsh -f scripts/test-git-chroma-regions.zsh`
- Native `zsh -n` and `zcompile`: 45 files passed
- Standalone integration scripts: 5 passed
- ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 13 passed, 0 failed
- `git diff --check`

Closes #38.
