### PR TITLE
fix(plugin): respect a user-set ZSH_HIGHLIGHT_MAXLENGTH

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -341,7 +341,11 @@ fi
   builtin print -r -- "$@" >>! /tmp/reply
 }
 
-typeset -g ZSH_HIGHLIGHT_MAXLENGTH=10000
+# Respect a value the user set before loading; only supply the default when
+# unset. This is the documented knob for capping highlighting on long buffers,
+# so overwriting it removes the user's only mitigation.
+typeset -g ZSH_HIGHLIGHT_MAXLENGTH
+: ${ZSH_HIGHLIGHT_MAXLENGTH:=10000}
 
 # Load zsh/parameter module if available
 zmodload zsh/parameter 2>/dev/null


### PR DESCRIPTION
## Summary

`F-Sy-H.plugin.zsh` assigned `ZSH_HIGHLIGHT_MAXLENGTH` unconditionally, so a
value set in `.zshrc` before loading the plugin was silently discarded.

## Reproduction on `main`

```zsh
ZSH_HIGHLIGHT_MAXLENGTH=200
source F-Sy-H.plugin.zsh
print $ZSH_HIGHLIGHT_MAXLENGTH
# 10000
```

## Why it matters

This is the documented zsh-syntax-highlighting knob and the only user-facing
control over highlighting cost on long buffers. Overwriting it removes the
user's ability to protect themselves, and nothing reports that it happened.

## Change

Declare the parameter global, then supply the default only when unset. This
matches the idiom already used elsewhere in the plugin, for example
`functions/fast-highlight`:

```zsh
: ${FAST_HIGHLIGHT[use_brackets]:=1}
```

## Verification

| case | result |
| ---- | ------ |
| pre-set to `200` before load | stays `200` |
| unset before load | defaults to `10000` |

- `zsh -n` and `zcompile` pass on the changed file, matching the `zsh-n` workflow.
- ZUnit: 13 passed, 0 failed, 0 errors. The same suite passes unchanged on
  `main`, so this neither fixes nor breaks existing coverage.

## Scope

One file, five lines. Independent of #81 and #83; the three branches merge
cleanly in any order.

Closes #94
