### PR TITLE
fix(themes): restore the subcommand style in z-shell and zdharma

### DIFF
--- a/themes/z-shell.ini
+++ b/themes/z-shell.ini
@@ -16,7 +16,7 @@ recursive-base   = 190
 
 [command-point]
 reserved-word  = 48
-reserved-word  = 48
+subcommand     = 51
 alias          = 93
 suffix-alias   = 93
 global-alias   = bg:19

--- a/themes/zdharma.ini
+++ b/themes/zdharma.ini
@@ -16,7 +16,7 @@ recursive-base   = 186
 
 [command-point]
 reserved-word  = 146
-reserved-word  = 146
+subcommand     = 117
 alias          = 63
 suffix-alias   = 63
 global-alias   = bg:19


### PR DESCRIPTION
## Summary

`themes/z-shell.ini` and `themes/zdharma.ini` each declared `reserved-word`
twice on consecutive lines in `[command-point]`. The ini parser keeps the last
value, so the duplicate was discarded and `subcommand` was never defined.

## Evidence

Before, `themes/z-shell.ini:17-20`:

```ini
[command-point]
reserved-word  = 48
reserved-word  = 48
alias          = 93
```

Every other shipped theme has `subcommand` in exactly that position:

```ini
; themes/default.ini      ; themes/clean.ini       ; themes/base16.ini
reserved-word  = yellow   reserved-word  = 146     reserved-word  = 5
subcommand     = yellow   subcommand     = 146     subcommand     = 6
```

so the second line was a copy-paste error, not an intentional duplicate.

With `subcommand` undefined it resolved through the fallback chain to
`reserved-word`, which is why a `git` subcommand and a shell reserved word
rendered identically in these two themes. `z-shell` is the default theme.

Introduced in 899f68b.

## Colour choice

Picked to stay near each theme's palette while remaining perceptually separate
from both `reserved-word` and the surrounding command-point colour, rather than
copying the neighbouring value:

| theme | value | RGB distance from `reserved-word` | contrast on black |
| ----- | ----- | --------------------------------- | ----------------- |
| `z-shell` | `51` | 120.0 | 16.75:1 |
| `zdharma` | `117` | 69.3 | 13.19:1 |

I first tried `152` for `zdharma` and rejected it: at distance 40.0 from
`reserved-word` it was too close to read as a different token.

## Verification

Both themes now resolve the two styles distinctly:

```
z-shell  reserved=fg=48   subcommand=fg=51   DISTINCT
zdharma  reserved=fg=146  subcommand=fg=117  DISTINCT
```

- `Missing style: subcommand` is no longer reported on load.
- End to end, `git fetch origin` now highlights `fetch` as `subcommand`
  (`fg=51`) rather than as a reserved word.
- ZUnit: 13 passed, 0 failed, 0 errors.

## Scope

Two files, one line each. Deliberately does **not** touch the `comment` style
in these files; that belongs to #83 and is handled in its own pull request.
Independent of #94 and #83; the three branches merge cleanly in any order.

Closes #81
