### PR TITLE
refactor: harden themes and chroma runtime

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -61,8 +61,15 @@ jobs:
           zsh -f -i tests/integration/test-plugin-lifecycle.zsh interactive
           zsh -f tests/integration/test-function-completion.zsh
           zsh -f tests/integration/test-git-chroma-regions.zsh
+          zsh -f tests/integration/test-git-runtime-knowledge.zsh
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
+          zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-theme-persistence.zsh
+          zsh -f tests/integration/test-chroma-registry.zsh
+          zsh -f tests/integration/test-chroma-regions.zsh
+          zsh -f tests/integration/test-async-chroma.zsh
+          zsh -f tests/integration/test-theme-validator.zsh
 
   current:
     name: Zsh 5.9.2
@@ -119,8 +126,15 @@ jobs:
           zsh -f -i tests/integration/test-plugin-lifecycle.zsh interactive
           zsh -f tests/integration/test-function-completion.zsh
           zsh -f tests/integration/test-git-chroma-regions.zsh
+          zsh -f tests/integration/test-git-runtime-knowledge.zsh
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
+          zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-theme-persistence.zsh
+          zsh -f tests/integration/test-chroma-registry.zsh
+          zsh -f tests/integration/test-chroma-regions.zsh
+          zsh -f tests/integration/test-async-chroma.zsh
+          zsh -f tests/integration/test-theme-validator.zsh
 
   required:
     name: Zsh

--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -424,9 +424,12 @@ builtin autoload -Uz -- \
   _fsh_chroma_ssh \
   _fsh_chroma_subcommand \
   _fsh_chroma_subversion \
-  _fsh_chroma_whatis \
   _fsh_chroma_zi \
   _fsh_chroma_main
+
+# Kept in sync with the platform guard in lib/highlight.zsh: macOS `whatis`
+# cannot serve this chroma, so it is neither autoloaded nor registered there.
+[[ $OSTYPE == darwin* ]] || builtin autoload -Uz -- _fsh_chroma_whatis
 
 configured_patterns=()
 if zstyle -a ':fsh:config' chroma-opt-in configured_patterns; then

--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -53,6 +53,11 @@ fi
 
 builtin source -- "$plugin_dir/lib/lifecycle.zsh" || return
 _fsh_lifecycle_begin "${lifecycle_modules[@]}" || return
+builtin source -- "$plugin_dir/lib/theme-schema.zsh" || {
+  load_status=$?
+  _fsh_lifecycle_abort "$load_status"
+  return $?
+}
 
 #
 # Resolve the entrypoint without assigning to special parameter 0. Plugin
@@ -80,14 +85,32 @@ else
 fi
 _fsh_work_dir=${~_fsh_work_dir}
 
-configured_value=10000
-zstyle -s ':fsh:config' max-length configured_value || configured_value=10000
+configured_value=1000
+zstyle -s ':fsh:config' max-length configured_value || configured_value=1000
 [[ $configured_value == <-> ]] || {
   builtin print -u2 -r -- 'f-sy-h: :fsh:config max-length must be a non-negative integer'
   _fsh_lifecycle_abort 2
   return $?
 }
 typeset -gi _fsh_max_length=$configured_value
+
+configured_value=5
+zstyle -s ':fsh:config' chroma-cache-seconds configured_value || configured_value=5
+[[ $configured_value == <-> ]] || {
+  builtin print -u2 -r -- 'f-sy-h: :fsh:config chroma-cache-seconds must be a non-negative integer'
+  _fsh_lifecycle_abort 2
+  return $?
+}
+typeset -gi _fsh_chroma_cache_seconds=$configured_value
+
+configured_value=2
+zstyle -s ':fsh:config' chroma-timeout-seconds configured_value || configured_value=2
+[[ $configured_value == <-> && $configured_value -gt 0 ]] || {
+  builtin print -u2 -r -- 'f-sy-h: :fsh:config chroma-timeout-seconds must be a positive integer'
+  _fsh_lifecycle_abort 2
+  return $?
+}
+typeset -gi _fsh_chroma_timeout_seconds=$configured_value
 
 # Invokes each highlighter that needs updating.
 # This function is supposed to be called whenever the ZLE state changes.
@@ -107,8 +130,8 @@ _fsh_zle_highlight() {
   local REPLY # don't leak $REPLY into global scope
   local -a reply
 
-  # Do not highlight if there are more than 300 chars in the buffer. It's most
-  # likely a pasted command or a huge list of files in that case..
+  # Skip highlighting above the configured buffer-length limit. Long buffers
+  # are commonly pasted commands or generated lists.
   [[ -n ${_fsh_max_length:-} ]] && [[ $#BUFFER -gt $_fsh_max_length ]] && return $ret
 
   # Do not highlight if there are pending inputs (copy/paste).
@@ -351,6 +374,7 @@ if [[ -o interactive ]]; then
     _fsh_lifecycle_abort 1
     return $?
   }
+  zle -N _fsh_async_command_callback
   _fsh_bind_widgets || {
     builtin print -u2 -r -- 'f-sy-h: failed binding ZLE widgets'
     _fsh_lifecycle_abort 1
@@ -370,10 +394,10 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 builtin autoload -Uz -- is-at-least \
-  _fsh_read_ini _fsh_run_git_command \
-  _fsh_make_targets _fsh_run_command _fsh_read_all
+  _fsh_read_ini _fsh_validate_theme _fsh_run_git_command \
+  _fsh_make_targets _fsh_run_command _fsh_read_all \
+  _fsh_async_command _fsh_async_command_callback
 
-# Disabled: _fsh_chroma_vim _fsh_chroma_which
 builtin autoload -Uz -- \
   _fsh_chroma_alias \
   _fsh_chroma_autoload \
@@ -390,7 +414,6 @@ builtin autoload -Uz -- \
   _fsh_chroma_nice \
   _fsh_chroma_nmcli \
   _fsh_chroma_node \
-  _fsh_chroma_ogit \
   _fsh_chroma_perl \
   _fsh_chroma_precommand \
   _fsh_chroma_printf \
@@ -404,6 +427,23 @@ builtin autoload -Uz -- \
   _fsh_chroma_whatis \
   _fsh_chroma_zi \
   _fsh_chroma_main
+
+configured_patterns=()
+if zstyle -a ':fsh:config' chroma-opt-in configured_patterns; then
+  for configured_pattern in "${configured_patterns[@]}"; do
+    case $configured_pattern in
+      vim|which)
+        builtin autoload -Uz -- "_fsh_chroma_$configured_pattern"
+        ;;
+      *)
+        builtin print -u2 -r -- \
+          "f-sy-h: unsupported :fsh:config chroma-opt-in value: $configured_pattern"
+        _fsh_lifecycle_abort 2
+        return $?
+        ;;
+    esac
+  done
+fi
 
 configured_value=enabled
 zstyle -s ':fsh:config' theme-manager configured_value || configured_value=enabled
@@ -424,6 +464,10 @@ builtin source -- "$_fsh_base_dir/lib/string-highlight.zsh" || {
   _fsh_lifecycle_abort "$load_status"
   return $?
 }
+
+for configured_pattern in "${configured_patterns[@]}"; do
+  _fsh_state[chroma-$configured_pattern]="_fsh_chroma_$configured_pattern"
+done
 
 configured_value=enabled
 zstyle -s ':fsh:config' bracket-highlighting configured_value || configured_value=enabled

--- a/README.md
+++ b/README.md
@@ -129,10 +129,13 @@ All ordinary settings use `:fsh:config`. Set them before loading the plugin:
 
 ```zsh
 zstyle ':fsh:config' work-dir "${XDG_CACHE_HOME:-$HOME/.cache}/f-sy-h"
-zstyle ':fsh:config' max-length 10000
+zstyle ':fsh:config' max-length 1000
 zstyle ':fsh:config' theme-manager enabled
 zstyle ':fsh:config' bracket-highlighting enabled
 zstyle ':fsh:config' path-blocklist '/private/*' '/mnt/slow/**'
+zstyle ':fsh:config' chroma-opt-in vim
+zstyle ':fsh:config' chroma-cache-seconds 5
+zstyle ':fsh:config' chroma-timeout-seconds 2
 zi light z-shell/F-Sy-H
 ```
 
@@ -140,11 +143,19 @@ The settings are:
 
 - `work-dir`: scalar path, default
   `${XDG_CACHE_HOME:-$HOME/.cache}/f-sy-h`.
-- `max-length`: non-negative integer, default `10000`.
+- `max-length`: non-negative integer, default `1000`.
 - `theme-manager`: boolean-like scalar, default `enabled`.
 - `bracket-highlighting`: boolean-like scalar, default `enabled`.
 - `path-blocklist`: array of Zsh patterns excluded from path probing, empty by
   default.
+- `chroma-opt-in`: array containing `vim`, `which`, or both, empty by default.
+  The `vim` chroma reads `.viminfo` and displays recent files. The `which`
+  chroma runs multiple command-discovery tools while highlighting.
+- `chroma-cache-seconds`: non-negative lifetime for asynchronous chroma lookup
+  results, default `5`.
+- `chroma-timeout-seconds`: positive time budget for an asynchronous chroma
+  worker, default `2`. A worker that exceeds it is disabled for the session
+  and reports one ZLE warning.
 
 For boolean-like settings, `disabled`, `false`, `no`, `off`, and `0` disable
 the feature; any other value enables it.
@@ -210,8 +221,24 @@ zsh -f tests/integration/test-function-completion.zsh
 zsh -f tests/integration/test-git-chroma-regions.zsh
 zsh -f tests/integration/test-passive-safety.zsh
 zsh -f tests/integration/test-hostile-autoloads.zsh
+zsh -f tests/integration/test-highlight-budget.zsh
+zsh -f tests/integration/test-theme-persistence.zsh
+zsh -f tests/integration/test-chroma-registry.zsh
+zsh -f tests/integration/test-chroma-regions.zsh
+zsh -f tests/integration/test-async-chroma.zsh
+zsh -f tests/integration/test-theme-validator.zsh
+zsh -f tools/validate-themes.zsh
 zunit
 ```
+
+The highlight-budget profile measures five parses of a fixed 1,000-character
+buffer after one warm-up run. Its median must remain at or below 250 ms, and a
+buffer above the default limit must take the skip path.
+
+`tools/validate-themes.zsh` validates all shipped themes by default and accepts
+explicit INI paths as arguments. It emits one JSON Lines record per result or
+diagnostic using schema `fsh-theme-validation/v1`, and exits non-zero if any
+record has `status` set to `error`.
 
 The ZUnit command requires the repository's pinned ZUnit toolchain.
 

--- a/chroma/_fsh_chroma_docker
+++ b/chroma/_fsh_chroma_docker
@@ -32,7 +32,6 @@ local -a _fsh_command_output
     _fsh_state[chroma-docker-counter]=0
     _fsh_state[chroma-docker-got-subcommand]=0
     _fsh_state[chroma-docker-subcommand]=""
-    _fsh_state[chrome-docker-got-msg1]=0
     return 1
 } || {
     # Following call, i.e. not the first one
@@ -63,7 +62,7 @@ local -a _fsh_command_output
                     if (( __idx1 == 2 )); then
                         __style=${_fsh_theme_name}subcommand
                     elif (( __idx1 == 3 )); then
-                        _fsh_run_command "docker images -q" chroma-docker-list ""
+                        _fsh_async_command chroma-docker-list docker images -q
                         [[ -n "${_fsh_command_output[(r)$__wrd]}" ]] && {
                             (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER}, __start >= 0 )) && \
                                 reply+=("$__start $__end ${_fsh_styles[${_fsh_theme_name}correct-subtle]}")

--- a/chroma/_fsh_chroma_git
+++ b/chroma/_fsh_chroma_git
@@ -600,9 +600,6 @@ _fsh_chroma_git_first_call() {
   _fsh_state[chroma-git-counter]=0
   _fsh_state[chroma-git-got-subcommand]=0
   _fsh_state[chroma-git-subcommand]=""
-  _fsh_state[chrome-git-got-msg1]=0
-  _fsh_state[chrome-git-got-anymsg]=0
-  _fsh_state[chrome-git-occurred-double-hyphen]=0
   _fsh_state[chroma-git-checkout-new]=0
   _fsh_state[chroma-git-fetch-multiple]=0
   _fsh_state[chroma-git-branch-change]=0
@@ -613,45 +610,222 @@ _fsh_chroma_git_first_call() {
 }
 
 _fsh_chroma_git_check_alias() {
-  local _wrd="$1"
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+  local _wrd=$1 resolved
   local -a _result
+
+  resolved=$_wrd
 
   typeset -ga _fsh_chroma_git_aliases
   _result=( ${(M)_fsh_chroma_git_aliases[@]:#${_wrd}[[:space:]]##*} )
   _fsh_chroma_debug "Got is-alias-_result: $_result"
-  [[ -n "$_result" ]] && \
-  _fsh_state[chroma-${_fsh_state[chroma-current]}-subcommand]="${${${_result#* }## ##}%% *}"
+  if [[ -n "$_result" ]]; then
+    resolved="${${${_result[1]#* }## ##}%% *}"
+    _fsh_state[chroma-${_fsh_state[chroma-current]}-subcommand]=$resolved
+  fi
+  _fsh_chroma_git_prepare_runtime_options "$resolved"
 }
 
-# A hook that returns the list of git's
-# available subcommands in $reply
-_fsh_chroma_git_get_subcommands() {
-  local __svalue
-  integer __ivalue
-  LANG=C _fsh_run_command "git help -a" chroma-${_fsh_state[chroma-current]}-subcmd-list "" $(( 15 * 60 ))
+# Parse the indented command rows emitted by `git help -a'. Headings and prose
+# are deliberately ignored so an unexpected help layout falls back safely.
+_fsh_chroma_git_parse_subcommands() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
-  if [[ "${_fsh_command_output[1]}" = See* ]]; then
-    # (**)
-    # git >= v2.20, the aliases in the `git help -a' command
-    _fsh_command_output=( ${${${${(M)_fsh_command_output[@]:#([[:space:]](#c3,3)[a-zA-Z0-9_]*|Command aliases)}##[[:space:]]##}//(#s)Command\ aliases(#e)/Command_aliases}} )
-    __svalue="+${_fsh_command_output[(I)Command_aliases]}"
-    _fsh_command_output[1,__svalue-1]=( ${(@)_fsh_command_output[1,__svalue-1]%%[[:space:]]##*} )
+  local line trimmed command_name
+  local -A seen=()
+  _fsh_git_parse_reply=()
+
+  for line in "$@"; do
+    trimmed=${line##[[:space:]]##}
+    [[ $trimmed == 'External commands'* ||
+       $trimmed == 'Command aliases'* ]] && break
+    [[ $line == [[:space:]]##* ]] || continue
+    [[ $trimmed == [a-zA-Z0-9][a-zA-Z0-9._-]#[[:space:]]##* ]] || continue
+    command_name=${trimmed%%[[:space:]]*}
+    [[ $command_name == [a-zA-Z0-9][a-zA-Z0-9._-]# ]] || continue
+    (( ${+seen[$command_name]} )) || _fsh_git_parse_reply+=( "$command_name" )
+    seen[$command_name]=1
+  done
+}
+
+_fsh_chroma_git_canonical_option() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+  local option=${1%,}
+  integer has_equals=0
+
+  [[ $option == *\=* ]] && has_equals=1
+  option=${option%%\[*}
+  option=${option%%\<*}
+  (( has_equals )) && option=${option%%=*}=
+  [[ $option == --[a-zA-Z0-9][a-zA-Z0-9_-]#(|=) ||
+     $option == -[a-zA-Z0-9](|=) ]] || return 1
+  canonical_option=$option
+}
+
+# Parse option spellings from the synopsis column emitted by `git <cmd> -h'.
+# Optional --[no-] forms are expanded because both spellings are accepted.
+_fsh_chroma_git_parse_options() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+  local line trimmed synopsis token canonical_option
+  local -A seen=()
+  local -a tokens candidates
+  _fsh_git_parse_reply=()
+
+  for line in "$@"; do
+    trimmed=${line##[[:space:]]##}
+    [[ $trimmed == -* ]] || continue
+    synopsis=${trimmed%%[[:space:]][[:space:]]*}
+    tokens=( ${=synopsis} )
+    for token in "${tokens[@]}"; do
+      token=${token%,}
+      [[ $token == -* ]] || continue
+      if [[ $token == *'[no-]'* ]]; then
+        candidates=( "${token/'[no-]'/}" "${token/'[no-]'/no-}" )
+      else
+        candidates=( "$token" )
+      fi
+      for token in "${candidates[@]}"; do
+        _fsh_chroma_git_canonical_option "$token" || continue
+        (( ${+seen[$canonical_option]} )) || _fsh_git_parse_reply+=( "$canonical_option" )
+        seen[$canonical_option]=1
+      done
+    done
+  done
+}
+
+_fsh_chroma_git_prepare_runtime_options() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+  local subcommand=$1 safe_subcommand key definition_id previous_id current_entry node generation_marker
+  integer inserted=0
+  local -a runtime_output runtime_options _fsh_git_parse_reply nodes updated_nodes
+  local -a safe_subcommands
+
+  [[ $subcommand == [a-zA-Z0-9][a-zA-Z0-9._-]# ]] || return 0
+  safe_subcommands=( "${(@f)_fsh_state[chroma-git-runtime-safe-subcommands]-}" )
+  (( safe_subcommands[(Ie)$subcommand] )) || return 0
+  safe_subcommand=${subcommand//[^a-zA-Z0-9_]/_}
+  key=chroma-git-options-$safe_subcommand
+  _fsh_state[$key-cache-seconds]=$(( 15 * 60 ))
+  _fsh_async_command --capture-stderr "$key" env LC_ALL=C git "$subcommand" -h
+  runtime_output=( "${_fsh_command_output[@]}" )
+  (( ${_fsh_state[$key-cache-ready]:-0} )) || return 0
+
+  _fsh_chroma_git_parse_options "${runtime_output[@]}"
+  runtime_options=( "${_fsh_git_parse_reply[@]}" )
+  (( $#runtime_options )) || return 0
+
+  previous_id=${_fsh_state[$key-definition-id]-}
+  if [[ -n $previous_id &&
+        ${_fsh_state[$key-definition-born-at]-} == ${_fsh_state[$key-cache-born-at]} ]]; then
+    definition_id=$previous_id
   else
-    # (**)
-    # git < v2.20, add aliases through extra code
-    _fsh_command_output=( ${(s: :)${(M)_fsh_command_output[@]:#  [a-z]*}} )
-    __svalue=${#_fsh_command_output}
-    # This allows to check if the command is an alias - we want to
-    # highlight the aliased command just like the target command of the alias
-    _fsh_run_command "+git config --get-regexp 'alias.*'" chroma-${_fsh_state[chroma-current]}-alias-list "[[:space:]]#alias." $(( 15 * 60 ))
+    (( ++ _fsh_state[$key-definition-generation] ))
+    generation_marker=${(l:${_fsh_state[$key-definition-generation]}::R:)}
+    definition_id="GIT_RUNTIME_${safe_subcommand}_${generation_marker}_#_opt"
+    _fsh_state[$key-definition-born-at]=${_fsh_state[$key-cache-born-at]}
+  fi
+  if [[ -n $previous_id && $previous_id != $definition_id ]]; then
+    builtin unset "_fsh_chroma_git_def[$previous_id]"
+  fi
+  _fsh_state[$key-definition-id]=$definition_id
+  _fsh_chroma_git_def[$definition_id]="
+    (${(j:|:)runtime_options})
+      <<>> NO-OP // ::_fsh_chroma_option_separator_action"
+
+  current_entry=${_fsh_chroma_main_git[subcmd:$subcommand]-}
+  if [[ -z $current_entry ]]; then
+    current_entry=$definition_id' // CATCH_ALL_#_opt'
+  else
+    nodes=( "${(@s://:)current_entry}" )
+    updated_nodes=()
+    for node in "${nodes[@]}"; do
+      node=${node//((#s)[[:space:]]##|[[:space:]]##(#e))/}
+      [[ -n $previous_id && $node == $previous_id ]] && continue
+      if (( ! inserted )) && [[ $node == NO_MATCH_*_opt ]]; then
+        updated_nodes+=( "$definition_id" )
+        inserted=1
+      fi
+      updated_nodes+=( "$node" )
+    done
+    if (( ! inserted )); then
+      updated_nodes+=( "$definition_id" )
+    fi
+    current_entry=${(j: // :)updated_nodes}
+  fi
+  _fsh_chroma_main_git[subcmd:$subcommand]=$current_entry
+}
+
+# Return Git subcommands in $reply. Runtime output is authoritative when it is
+# available; the frozen list keeps first paint and unavailable Git installs
+# deterministic.
+_fsh_chroma_git_get_subcommands() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+  local line alias_name alias_value alias_target
+  local -a fallback runtime_output runtime_subcommands alias_output alias_names _fsh_git_parse_reply
+  local -A seen=()
+
+  fallback=(
+    add am archive bisect branch bundle checkout cherry-pick clean clone commit
+    describe diff fetch format-patch gc grep init log maintenance merge mv notes
+    pull push range-diff rebase reset restore revert rm shortlog show
+    sparse-checkout stash status submodule switch tag worktree config reflog
+    remote replace blame bugreport count-objects diagnose difftool fsck help
+    merge-tree rerere show-branch verify-commit verify-tag version
+  )
+
+  _fsh_state[chroma-git-subcommands-cache-seconds]=$(( 15 * 60 ))
+  _fsh_async_command chroma-git-subcommands env LC_ALL=C git help -a
+  runtime_output=( "${_fsh_command_output[@]}" )
+  if (( ${_fsh_state[chroma-git-subcommands-cache-ready]:-0} )); then
+    _fsh_chroma_git_parse_subcommands "${runtime_output[@]}"
+    runtime_subcommands=( "${_fsh_git_parse_reply[@]}" )
+    if (( $#runtime_subcommands )); then
+      _fsh_state[chroma-git-subcommands-last-valid]=${(F)runtime_subcommands}
+    fi
+  fi
+  if (( ! $#runtime_subcommands )) &&
+      (( ${+_fsh_state[chroma-git-subcommands-last-valid]} )); then
+    runtime_subcommands=( "${(@f)_fsh_state[chroma-git-subcommands-last-valid]}" )
+  fi
+  (( $#runtime_subcommands )) || runtime_subcommands=( "${fallback[@]}" )
+  _fsh_state[chroma-git-runtime-safe-subcommands]=${(F)runtime_subcommands}
+
+  _fsh_state[chroma-git-aliases-cache-seconds]=$(( 15 * 60 ))
+  _fsh_async_command chroma-git-aliases env LC_ALL=C git config --get-regexp '^alias\.'
+  alias_output=( "${_fsh_command_output[@]}" )
+  typeset -ga _fsh_chroma_git_aliases
+  _fsh_chroma_git_aliases=()
+  if (( ${_fsh_state[chroma-git-aliases-cache-ready]:-0} )); then
+    for line in "${alias_output[@]}"; do
+      alias_name=${line%%[[:space:]]*}
+      alias_value=${line#${alias_name}}
+      alias_value=${alias_value##[[:space:]]##}
+      alias_name=${alias_name#alias.}
+      [[ $alias_name == [a-zA-Z0-9][a-zA-Z0-9._-]# && $alias_value != '!'* ]] || continue
+      alias_target=${alias_value%%[[:space:]]*}
+      [[ $alias_target == [a-zA-Z0-9][a-zA-Z0-9._-]# ]] || continue
+      (( runtime_subcommands[(Ie)$alias_target] )) || continue
+      alias_names+=( "$alias_name" )
+      _fsh_chroma_git_aliases+=( "$alias_name $alias_target" )
+    done
   fi
 
-  __tmp=${#_fsh_command_output}
-  typeset -ga _fsh_chroma_git_aliases
-  _fsh_chroma_git_aliases=( ${_fsh_command_output[__svalue+1,__tmp]} )
-  [[ ${_fsh_command_output[__svalue]} != "Command_aliases" ]] && (( ++ __svalue, __ivalue=0, 1 )) || (( __ivalue=1 ))
-  _fsh_command_output[__svalue,__tmp]=( ${(@)_fsh_command_output[__svalue+__ivalue,__tmp]%%[[:space:]]##*} )
-  reply=( "${_fsh_command_output[@]}" )
+  reply=()
+  for line in "${runtime_subcommands[@]}" "${alias_names[@]}"; do
+    (( ${+seen[$line]} )) || reply+=( "$line" )
+    seen[$line]=1
+  done
 }
 
 # A generic handler

--- a/chroma/_fsh_chroma_main
+++ b/chroma/_fsh_chroma_main
@@ -49,7 +49,7 @@ local __chroma_name="${1#\%}" __first_call="$2" __wrd="$3" __start_pos="$4" __en
 
 _fsh_chroma_debug -r -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 _fsh_chroma_debug -r -- @@@@@@@  local __chroma_name="${1#\%}" __first_call="$2" __wrd="$3" __start_pos="$4" __end_pos="$5" @@@@@@@
-local __style __entry __value __action __handler __tmp __svalue __hspaces=$'\t ' __nl=$'\n' __ch_def_name
+local __style __entry __value __action __handler __tmp __svalue __subcmd_hook __hspaces=$'\t ' __nl=$'\n' __ch_def_name
 integer __idx1 __idx2 __start __end __ivalue __have_value=0
 local -a _fsh_command_output __avalue
 local -A map
@@ -337,6 +337,21 @@ _fsh_chroma_process_token() {
 
 # Iterates over the chroma def. fields and creates initial
 # fields in the _fsh_chroma_${__chroma_name}_def hash
+_fsh_chroma_refresh_subcommands() {
+  local __the_hash_name=$1 __var_name
+  local -a reply
+
+  __ch_def_name="_fsh_chroma_${__chroma_name}_def[subcommands]"
+  local __subcmds="${(P)__ch_def_name}"
+  __var_name="${__the_hash_name}[subcommands]"
+  if [[ "$__subcmds" = "::"* ]]; then
+    ${__subcmds#::}
+    : ${(P)__var_name::=(${(j:|:)reply})}
+  else
+    : ${(P)__var_name::=$__subcmds}
+  fi
+}
+
 _fsh_chroma_preprocess_definition() {
   local __key __value __ke _val __the_hash_name="$1" __var_name
   # Keep callback results separate from the caller's highlight accumulator.
@@ -344,16 +359,8 @@ _fsh_chroma_preprocess_definition() {
 
   _fsh_chroma_debug -rl -- "Starting PRE_PROCESS for __the_hash_name:$__the_hash_name"
 
-  __ch_def_name="_fsh_chroma_${__chroma_name}_def[subcommands]"
-  local __subcmds="${(P)__ch_def_name}"
-  if [[ "$__subcmds" = "::"* ]]; then
-    ${__subcmds#::}
-    __var_name="${__the_hash_name}[subcommands]"
-    : ${(P)__var_name::=(${(j:|:)reply})}
-  else
-    __var_name="${__the_hash_name}[subcommands]"
-    : ${(P)__var_name::=$__subcmds}
-  fi
+  _fsh_chroma_refresh_subcommands "$__the_hash_name"
+  __var_name="${__the_hash_name}[subcommands]"
   _fsh_chroma_debug "Got SUBCOMMANDS: ${(P)__var_name}"
 
   __ch_def_name="_fsh_chroma_${__chroma_name}_def[subcmd-hook]"
@@ -383,7 +390,6 @@ if (( __first_call )); then
   _fsh_state[chroma-${_fsh_state[chroma-current]}-counter-arg]=0
   _fsh_state[chroma-${_fsh_state[chroma-current]}-got-subcommand]=0
   _fsh_state[chroma-${_fsh_state[chroma-current]}-subcommand]=""
-  _fsh_state[chrome-${_fsh_state[chroma-current]}-occurred-double-hyphen]=0
   _fsh_state[chroma-${_fsh_state[chroma-current]}-option-with-arg-active]=""
   _fsh_state[chroma-${_fsh_state[chroma-current]}-option-arg]=""
   _fsh_state[chroma-${_fsh_state[chroma-current]}-call-nr]=1
@@ -393,7 +399,10 @@ if (( __first_call )); then
   (( 0 == ${(P)+__the_hash_name} )) && {
     typeset -gA "$__the_hash_name"
     _fsh_chroma_preprocess_definition "$__the_hash_name"
-  } || _fsh_chroma_debug "...No... [\${+$__the_hash_name} ${(P)+__the_hash_name}]"
+  } || {
+    _fsh_chroma_refresh_subcommands "$__the_hash_name"
+    _fsh_chroma_debug "...No... [\${+$__the_hash_name} ${(P)+__the_hash_name}]"
+  }
   return 1
 else
   (( ++ _fsh_state[chroma-${_fsh_state[chroma-current]}-call-nr] ))
@@ -417,8 +426,12 @@ else
         _fsh_chroma_debug "GOT-SUBCOMMAND := $__wrd, subcmd verification / OK"
         _fsh_state[chroma-${_fsh_state[chroma-current]}-got-subcommand]=1
         _fsh_state[chroma-${_fsh_state[chroma-current]}-subcommand]="$__wrd"
-        __var_name="${__the_hash_name}[subcmd-hook]"
-        (( ${(P)+__var_name} )) && { _fsh_chroma_debug -r -- "Running subcmd-hook: ${(P)__var_name}" ; "${(P)__var_name}" "$__wrd"; }
+        __ch_def_name="_fsh_chroma_${__chroma_name}_def[subcmd-hook]"
+        __subcmd_hook=${(P)__ch_def_name}
+        [[ -n $__subcmd_hook ]] && {
+          _fsh_chroma_debug -r -- "Running subcmd-hook: $__subcmd_hook"
+          "$__subcmd_hook" "$__wrd"
+        }
         __style="${_fsh_theme_name}subcommand"
       else
         _fsh_chroma_debug "subcmd verif / NOT OK; Incrementing the COUNTER-ARG ${_fsh_state[chroma-${_fsh_state[chroma-current]}-counter-arg]} -> $(( _fsh_state[chroma-${_fsh_state[chroma-current]}-counter-arg] + 1 ))"

--- a/chroma/_fsh_chroma_perl
+++ b/chroma/_fsh_chroma_perl
@@ -28,7 +28,7 @@ integer __idx1 __idx2
   # _fsh_state is used because it survives between calls, and
   # allows to use a single global hash only, instead of multiple
   # global variables.
-  _fsh_state[chrome-perl-got-eswitch]=0
+  _fsh_state[chroma-perl-got-eswitch]=0
   return 1
 } || {
   # Following call, i.e. not the first one.
@@ -45,14 +45,14 @@ integer __idx1 __idx2
     __style=${_fsh_theme_name}${${${__wrd:#--*}:+single-hyphen-option}:-double-hyphen-option}
 
     if [[ "$__wrd" = "-e" || ("$__wrd" = -*e* && "$__wrd" != --*) ]]; then
-      _fsh_state[chrome-perl-got-eswitch]=1
+      _fsh_state[chroma-perl-got-eswitch]=1
     fi
   else
     __wrd="${__wrd//\`/x}"
     __arg="${__arg//\`/x}"
     __wrd="${(Q)__wrd}"
-    if (( _fsh_state[chrome-perl-got-eswitch] == 1 )); then
-      _fsh_state[chrome-perl-got-eswitch]=0
+    if (( _fsh_state[chroma-perl-got-eswitch] == 1 )); then
+      _fsh_state[chroma-perl-got-eswitch]=0
       __style=${_fsh_theme_name}single-quoted-argument
     else
       # Pass-through to the big-loop outside

--- a/chroma/_fsh_chroma_ruby
+++ b/chroma/_fsh_chroma_ruby
@@ -26,7 +26,7 @@ integer __idx1 __idx2
     # _fsh_state is used because it survives between calls, and
     # allows to use a single global hash only, instead of multiple
     # global variables.
-    _fsh_state[chrome-ruby-got-eswitch]=0
+    _fsh_state[chroma-ruby-got-eswitch]=0
     return 1
 } || {
     # Following call, i.e. not the first one.
@@ -43,19 +43,19 @@ integer __idx1 __idx2
         __style=${_fsh_theme_name}${${${__wrd:#--*}:+single-hyphen-option}:-double-hyphen-option}
 
         if [[ "$__wrd" = "-e" || ("$__wrd" = -*e* && "$__wrd" != --*) ]]; then
-            _fsh_state[chrome-ruby-got-eswitch]=1
+            _fsh_state[chroma-ruby-got-eswitch]=1
         fi
     else
         __wrd="${(Q)__wrd}"
-        if (( _fsh_state[chrome-ruby-got-eswitch] == 1 )); then
-            _fsh_state[chrome-ruby-got-eswitch]=0
+        if (( _fsh_state[chroma-ruby-got-eswitch] == 1 )); then
+            _fsh_state[chroma-ruby-got-eswitch]=0
             (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER}, __start >= 0 )) &&
                 reply+=("$__start $__end ${_fsh_styles[${_fsh_theme_name}single-quoted-argument]}")
         else
             # Pass-through to the big-loop outside
             return 1
         fi
-        _fsh_state[chrome-ruby-got-eswitch]=0
+        _fsh_state[chroma-ruby-got-eswitch]=0
     fi
 }
 

--- a/chroma/_fsh_chroma_shell
+++ b/chroma/_fsh_chroma_shell
@@ -23,7 +23,7 @@ local -a _fsh_command_output
 
 (( __first_call )) && {
     # Called for the first time - new command
-    _fsh_state[chrome-git-got-c]=0
+    _fsh_state[chroma-shell-got-c]=0
     return 1
 } || {
     # Following call, i.e. not the first one
@@ -40,7 +40,7 @@ local -a _fsh_command_output
     if [[ $__wrd = -* && $__wrd != -*c* ]]; then
         __style=${_fsh_theme_name}${${${__wrd:#--*}:+single-hyphen-option}:-double-hyphen-option}
     else
-        if (( _fsh_state[chrome-git-got-c] == 1 )); then
+        if (( _fsh_state[chroma-shell-got-c] == 1 )); then
             for (( __idx1 = 1, __idx2 = 1; __idx2 <= __asize; ++ __idx1 )); do
                 [[ ${__arg[__idx2]} = ${__wrd[__idx1]} ]] && break
                 while [[ ${__arg[__idx2]} != ${__wrd[__idx1]} ]]; do
@@ -51,11 +51,11 @@ local -a _fsh_command_output
                 [[ ${__arg[__idx2]} = ${__wrd[__idx1]} ]] && break
             done
 
-            _fsh_state[chrome-git-got-c]=0
+            _fsh_state[chroma-shell-got-c]=0
             (( _start_pos-__PBUFLEN >= 0 )) && \
                 _fsh_highlight_process "$PREBUFFER" "${__wrd}" "$(( __start_pos + __idx2 - 1 ))"
         elif [[ $__wrd = -*c* ]]; then
-            _fsh_state[chrome-git-got-c]=1
+            _fsh_state[chroma-shell-got-c]=1
         else
             return 1
         fi

--- a/functions/_fsh_async_command
+++ b/functions/_fsh_async_command
@@ -1,0 +1,97 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Run a chroma lookup outside the ZLE hot path.
+#
+# Optional $1 - --capture-stderr, merge standard error into the cached output
+# $1 - unique _fsh_state cache key after optional flags
+# $2... - command and arguments, passed without string evaluation
+#
+# Output is returned in _fsh_command_output. A fresh or stale cache is returned
+# immediately. When the cache is stale, one background worker refreshes it.
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+integer capture_stderr=0
+if [[ $1 == --capture-stderr ]]; then
+  capture_stderr=1
+  shift
+fi
+
+local key=$1 fd pid
+local -a command_args=( "${@:2}" )
+integer age cache_seconds owned_fd
+typeset -ga _fsh_command_output
+
+[[ -n $key && $#command_args -gt 0 ]] || return 2
+cache_seconds=${_fsh_state[$key-cache-seconds]:-$_fsh_chroma_cache_seconds}
+
+if (( ${+_fsh_state[$key-cache-ready]} )); then
+  _fsh_command_output=( "${(@f)_fsh_state[$key-cache]}" )
+else
+  _fsh_command_output=()
+fi
+
+if (( ${_fsh_state[$key-pending]:-0} )); then
+  age=$(( SECONDS - _fsh_state[$key-started-at] ))
+  if (( age >= _fsh_chroma_timeout_seconds )); then
+    fd=${_fsh_state[$key-fd]-}
+    if [[ $fd == <-> ]]; then
+      pid=${_fsh_lifecycle_owned_fd_pids[$fd]-}
+      zle -F -w "$fd" 2>/dev/null || zle -F "$fd" 2>/dev/null || true
+      [[ $pid == <-> ]] && builtin kill -TERM "$pid" 2>/dev/null || true
+      [[ $pid == <-> ]] && builtin wait "$pid" 2>/dev/null || true
+      owned_fd=$fd
+      { exec {owned_fd}<&- } 2>/dev/null || true
+      _fsh_lifecycle_release_fd "$fd"
+      builtin unset "_fsh_state[_fsh-async-fd-$fd-key]"
+    fi
+    _fsh_state[$key-pending]=0
+    _fsh_state[$key-disabled]=1
+    if (( ! ${_fsh_state[$key-warned]:-0} )); then
+      zle -M "f-sy-h: disabled slow chroma lookup: $key"
+      _fsh_state[$key-warned]=1
+    fi
+  fi
+  return 0
+fi
+
+(( ${_fsh_state[$key-disabled]:-0} )) && return 0
+if (( ${+_fsh_state[$key-cache-ready]} )); then
+  age=$(( SECONDS - _fsh_state[$key-cache-born-at] ))
+  (( age <= cache_seconds )) && return 0
+fi
+
+# zle with no arguments succeeds only while the line editor is active. Never
+# start a worker from non-interactive parsing or test-only direct calls.
+zle >/dev/null 2>&1 || return 0
+
+if (( capture_stderr )); then
+  exec {fd}< <(command "${command_args[@]}" 2>&1)
+else
+  exec {fd}< <(command "${command_args[@]}" 2>/dev/null)
+fi
+pid=${sysparams[procsubstpid]-}
+command true
+
+_fsh_state[$key-pending]=1
+_fsh_state[$key-started-at]=$SECONDS
+_fsh_state[$key-fd]=$fd
+_fsh_state[_fsh-async-fd-$fd-key]=$key
+_fsh_lifecycle_register_fd "$fd" _fsh_async_command_callback "$pid" || return 1
+zle -F -w "$fd" _fsh_async_command_callback || {
+  owned_fd=$fd
+  { exec {owned_fd}<&- } 2>/dev/null || true
+  [[ $pid == <-> ]] && builtin kill -TERM "$pid" 2>/dev/null || true
+  [[ $pid == <-> ]] && builtin wait "$pid" 2>/dev/null || true
+  _fsh_lifecycle_release_fd "$fd"
+  builtin unset \
+    "_fsh_state[$key-pending]" \
+    "_fsh_state[$key-started-at]" \
+    "_fsh_state[$key-fd]" \
+    "_fsh_state[_fsh-async-fd-$fd-key]"
+  return 1
+}
+
+return 0

--- a/functions/_fsh_async_command_callback
+++ b/functions/_fsh_async_command_callback
@@ -1,0 +1,36 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# zle -F widget for workers started by _fsh_async_command.
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local fd=$1 key input= pid
+integer owned_fd=$fd
+
+key=${_fsh_state[_fsh-async-fd-$fd-key]-}
+[[ -n $key ]] || return 1
+
+_fsh_read_all "$fd" input || true
+zle -F -w "$fd" 2>/dev/null || zle -F "$fd" 2>/dev/null || true
+pid=${_fsh_lifecycle_owned_fd_pids[$fd]-}
+{ exec {owned_fd}<&- } 2>/dev/null || true
+[[ $pid == <-> ]] && builtin wait "$pid" 2>/dev/null || true
+_fsh_lifecycle_release_fd "$fd"
+
+_fsh_state[$key-cache]=${input%$'\n'}
+_fsh_state[$key-cache-ready]=1
+_fsh_state[$key-cache-born-at]=$SECONDS
+_fsh_state[$key-pending]=0
+builtin unset \
+  "_fsh_state[$key-started-at]" \
+  "_fsh_state[$key-fd]" \
+  "_fsh_state[_fsh-async-fd-$fd-key]"
+
+typeset -g _fsh_prior_buffer=
+builtin true
+_fsh_zle_highlight
+zle -R
+
+return 0

--- a/functions/_fsh_read_ini
+++ b/functions/_fsh_read_ini
@@ -14,21 +14,44 @@ builtin emulate -L zsh
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 local __ini_file="$1" __out_hash="${2:-INI}" __key_prefix="$3"
-local IFS='' __line __cur_section="void" __access_string
+local IFS='' __line __cur_section= __access_string __record_key
 local -a match mbegin mend
+local -A __seen
+integer __line_number=0 __status=0
 
-[[ ! -r "$__ini_file" ]] && { builtin print -r "fast-syntax-highlighting: an ini file is unreadable ($__ini_file)"; return 1; }
+typeset -ga _fsh_ini_errors=()
+
+[[ -r "$__ini_file" ]] || {
+  _fsh_ini_errors+=( "unreadable-file|INI file is unreadable: $__ini_file" )
+  return 1
+}
 
 while read -r -t 1 __line; do
-  if [[ "$__line" = [[:blank:]]#\;* ]]; then
+  (( ++__line_number ))
+  if [[ "$__line" = [[:blank:]]# || "$__line" = [[:blank:]]#\;* ]]; then
     continue
   elif [[ "$__line" = (#b)[[:blank:]]#\[([-[:alnum:]_]##)\][[:blank:]]# ]]; then
     __cur_section="${match[1]}"
   elif [[ "$__line" = (#b)[[:blank:]]#([-[:alnum:]_]##)[[:blank:]]#[=][[:blank:]]#(*) ]]; then
+    [[ -n $__cur_section ]] || {
+      _fsh_ini_errors+=( "missing-section|line $__line_number: key appears before any section" )
+      __status=1
+      continue
+    }
     match[2]="${match[2]%"${match[2]##*[! $'\t']}"}" # remove trailing whitespace
+    __record_key="$__cur_section/${match[1]}"
+    if (( ${+__seen[$__record_key]} )); then
+      _fsh_ini_errors+=( "duplicate-key|line $__line_number: duplicate [$__cur_section] ${match[1]}" )
+      __status=1
+      continue
+    fi
+    __seen[$__record_key]=1
     __access_string="${__out_hash}[${__key_prefix}<$__cur_section>_${match[1]}]"
     : "${(P)__access_string::=${match[2]}}"
+  else
+    _fsh_ini_errors+=( "invalid-line|line $__line_number: invalid INI syntax" )
+    __status=1
   fi
 done < "$__ini_file"
 
-return 0
+return __status

--- a/functions/_fsh_validate_theme
+++ b/functions/_fsh_validate_theme
@@ -1,0 +1,126 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Validate one source theme against the canonical schema.
+#
+# $1 - theme INI path
+# $2 - shipped theme directory, used to resolve secondary theme names
+#
+# Results:
+# - _fsh_validated_theme_data: parsed INI records
+# - _fsh_theme_validation_errors: code|message diagnostics
+# - _fsh_theme_declared_count and _fsh_theme_resolved_count
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local theme_path=$1 theme_dir=$2 validation_mode=${3:-} full_key declared_key style candidate inikey value token
+local secondary_key secondary_name secondary_path required_key error
+local -A known declared_seen
+local -a candidates style_colors
+
+typeset -gA _fsh_validated_theme_data=()
+typeset -ga _fsh_theme_validation_errors=()
+typeset -gi _fsh_theme_declared_count=0 _fsh_theme_resolved_count=0
+
+if [[ -z $validation_mode ]]; then
+  [[ ${theme_path:t:r} == *overlay* ]] && validation_mode=overlay || validation_mode=full
+fi
+[[ $validation_mode == (full|overlay) ]] || {
+  _fsh_theme_validation_errors+=( "invalid-mode|unknown theme validation mode: $validation_mode" )
+  return 1
+}
+
+_fsh_read_ini "$theme_path" _fsh_validated_theme_data '' || {
+  for error in "${_fsh_ini_errors[@]}"; do
+    _fsh_theme_validation_errors+=( "$error" )
+  done
+  return 1
+}
+
+style_colors=( red green blue yellow cyan magenta black white default )
+for style in "${_fsh_theme_style_order[@]}"; do
+  known[$style]=1
+  for candidate in ${(s. .)_fsh_theme_style_fallbacks[$style]}; do
+    [[ $candidate == - ]] && candidate=$style
+    known[$candidate]=1
+  done
+done
+known[secondary]=1
+
+for full_key in ${(k)_fsh_validated_theme_data}; do
+  declared_key=${full_key#*>_}
+  if (( ! ${+known[$declared_key]} )); then
+    _fsh_theme_validation_errors+=( "unknown-style|unknown style declaration: $declared_key" )
+    continue
+  fi
+  if (( ${+declared_seen[$declared_key]} )); then
+    _fsh_theme_validation_errors+=( "duplicate-style|style declared in multiple sections: $declared_key" )
+    continue
+  fi
+  declared_seen[$declared_key]=1
+  (( ++_fsh_theme_declared_count ))
+
+  [[ $declared_key == secondary ]] && continue
+  value=${_fsh_validated_theme_data[$full_key]}
+  [[ -z $value ]] && continue
+  for token in ${(s:,:)value}; do
+    [[ $token == bg:* ]] && token=${token#bg:}
+    if [[ $token == (none|(no-|)(bold|blink|conceal|reverse|standout|underline)) ||
+      $token == (${(~j:|:)style_colors}) || $token == \#[0-9a-fA-F](#c6,6) ]]; then
+      continue
+    fi
+    if [[ $token == (0|[1-9][0-9]#) ]] && (( token <= 255 )); then
+      continue
+    fi
+    _fsh_theme_validation_errors+=( \
+      "invalid-style-value|$declared_key has invalid color or style element: $token" )
+  done
+done
+
+if [[ $validation_mode == full ]]; then
+  for style in "${_fsh_theme_style_order[@]}"; do
+    [[ $style == secondary ]] && continue
+    candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
+    required_key=$candidates[1]
+    [[ $required_key == - ]] && required_key=$style
+    (( ${+declared_seen[$required_key]} )) ||
+      _fsh_theme_validation_errors+=( "missing-style|missing required style declaration: $required_key" )
+
+    inikey=
+    for candidate in "${candidates[@]}"; do
+      [[ $candidate == - ]] && candidate=$style
+      inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
+      [[ -n $inikey ]] && break
+    done
+    if [[ -n $inikey ]]; then
+      (( ++_fsh_theme_resolved_count ))
+    else
+      _fsh_theme_validation_errors+=( "unresolved-style|cannot resolve style: $style" )
+    fi
+  done
+fi
+
+secondary_key=${_fsh_validated_theme_data[(i)<*>_secondary]}
+if [[ -n $secondary_key ]]; then
+  secondary_name=${_fsh_validated_theme_data[$secondary_key]}
+  if [[ -n $secondary_name ]]; then
+    secondary_path=$secondary_name
+    if [[ $secondary_path = */* || $secondary_path = (CONFIG|CACHE|LOCAL|HOME|OPT):* ]]; then
+      secondary_path="${${secondary_path/(#s)CONFIG:/${${XDG_CONFIG_HOME:-$HOME/.config}%/}/f-sy-h/}%.ini}.ini"
+      secondary_path="${${secondary_path/(#s)CACHE:/${${XDG_CACHE_HOME:-$HOME/.cache}%/}/f-sy-h/}%.ini}.ini"
+      secondary_path="${${secondary_path/(#s)LOCAL://usr/local/share/f-sy-h/}%.ini}.ini"
+      secondary_path="${${secondary_path/(#s)HOME:/$HOME/.f-sy-h/}%.ini}.ini"
+      secondary_path="${${secondary_path/(#s)OPT://opt/local/share/f-sy-h/}%.ini}.ini"
+      secondary_path=${~secondary_path}
+    else
+      secondary_path="$theme_dir/${secondary_name}.ini"
+    fi
+    [[ -f $secondary_path ]] ||
+      _fsh_theme_validation_errors+=( "missing-secondary|secondary theme does not exist: $secondary_name" )
+    [[ ! -e $secondary_path || -r $secondary_path ]] ||
+      _fsh_theme_validation_errors+=( "unreadable-secondary|secondary theme is unreadable: $secondary_name" )
+  fi
+fi
+
+(( $#_fsh_theme_validation_errors == 0 ))

--- a/functions/fsh_theme
+++ b/functions/fsh_theme
@@ -35,6 +35,7 @@ colors || return 1
 # exact prior declarations for every return path.
 {
 
+local temp_output_path=
 typeset -g _fsh_work_dir
 : ${_fsh_work_dir:=$_fsh_base_dir}
 _fsh_work_dir=${~_fsh_work_dir}
@@ -179,86 +180,7 @@ fi
 
 [[ -z "$1" ]] && { print -u2 "${fg[yellow]}Show help$reset_color: ${fg[cyan]}-h, --help$reset_color"; return 1; }
 
-# _fsh_styles key onto ini-file key
-map=(
-    default                     "-"
-    unknown-token               "-"
-    reserved-word               "-"
-    subcommand                  "- reserved-word"
-    alias                       "- command builtin"
-    suffix-alias                "- alias command builtin"
-    builtin                     "-"
-    function                    "- builtin command"
-    command                     "-"
-    precommand                  "- command"
-    commandseparator            "-"
-    hashed-command              "- command"
-    path                        "-"
-    path_pathseparator          "pathseparator"
-    globbing                    "- back-or-dollar-double-quoted-argument" # fallback: variable in string "text $var text"
-    globbing-ext                "- double-quoted-argument" # fallback: the string "abc..."
-    history-expansion           "-"
-    single-hyphen-option        "- single-quoted-argument"
-    double-hyphen-option        "- double-quoted-argument"
-    back-quoted-argument        "-"
-    single-quoted-argument      "-"
-    double-quoted-argument      "-"
-    dollar-quoted-argument      "-"
-    back-or-dollar-double-quoted-argument   "- back-dollar-quoted-argument"
-    back-dollar-quoted-argument             "- back-or-dollar-double-quoted-argument"
-    assign                      "- reserved-word"
-    redirection                 "- reserved-word"
-    comment                     "-"
-    variable                    "-"
-    mathvar                     "- forvar variable"
-    mathnum                     "- fornum"
-    matherr                     "- incorrect-subtle"
-    assign-array-bracket        "-"
-    for-loop-variable           "forvar mathvar variable"
-    for-loop-number             "fornum mathnum"
-    for-loop-operator           "foroper reserved-word"
-    for-loop-separator          "forsep commandseparator"
-    exec-descriptor             "- reserved-word"
-    here-string-tri             "-"
-    here-string-text            "- subtle-bg"
-    here-string-var             "- back-or-dollar-double-quoted-argument"
-    secondary                   "-"
-    recursive-base              "- default"
-    case-input                  "- variable"
-    case-parentheses            "- reserved-word"
-    case-condition              "- correct-subtle"
-    correct-subtle              "-"
-    incorrect-subtle            "-"
-    subtle-separator            "- commandseparator"
-    subtle-bg                   "- correct-subtle"
-    path-to-dir                 "- path"
-    paired-bracket              "- subtle-bg correct-subtle"
-    bracket-level-1             "-"
-    bracket-level-2             "-"
-    bracket-level-3             "-"
-    global-alias                "- alias suffix-alias"
-    single-sq-bracket           "-"
-    double-sq-bracket           "-"
-    double-paren                "-"
-    optarg-string               "- double-quoted-argument"
-    optarg-number               "- mathnum"
-)
-
-# In which order to generate entries
-local -a order
-order=(
-  default unknown-token reserved-word alias suffix-alias builtin function command precommand
-  commandseparator hashed-command path path_pathseparator globbing globbing-ext history-expansion
-  single-hyphen-option double-hyphen-option back-quoted-argument single-quoted-argument
-  double-quoted-argument dollar-quoted-argument back-or-dollar-double-quoted-argument
-  back-dollar-quoted-argument assign redirection comment variable mathvar
-  mathnum matherr assign-array-bracket for-loop-variable for-loop-number for-loop-operator
-  for-loop-separator exec-descriptor here-string-tri here-string-text here-string-var secondary
-  case-input case-parentheses case-condition correct-subtle incorrect-subtle subtle-separator subtle-bg
-  path-to-dir paired-bracket bracket-level-1 bracket-level-2 bracket-level-3
-  global-alias subcommand single-sq-bracket double-sq-bracket double-paren
-  optarg-string optarg-number recursive-base
-)
+local -a order=( "${_fsh_theme_style_order[@]}" )
 
 [[ -n "$OPT_VERBOSE" ]] && print "Number of styles available for customization: ${#order}"
 
@@ -271,7 +193,7 @@ style_colors=( red green blue yellow cyan magenta black white default )
 #
 
 local -A out
-local THEME_NAME THEME_PATH="$1"
+local THEME_NAME THEME_PATH="$1" theme_source
 if [[ "$1" = */* || "$1" = (CONFIG|CACHE|LOCAL|HOME|OPT):* ]]; then
   1="${${1/(#s)CONFIG:/${${XDG_CONFIG_HOME:-$HOME/.config}%/}/f-sy-h/}%.ini}.ini"
   1="${${1/(#s)CACHE:/${${XDG_CACHE_HOME:-$HOME/.cache}%/}/f-sy-h/}%.ini}.ini"
@@ -284,16 +206,34 @@ if [[ "$1" = */* || "$1" = (CONFIG|CACHE|LOCAL|HOME|OPT):* ]]; then
   [[ ! -r "$1" ]] && { print -u2 "${fg[yellow]}Theme$reset_color \`$1' ${fg[yellow]}unreadable, aborting$reset_color"; return 1; }
 
   THEME_NAME="${1:t:r}"
-  _fsh_read_ini "$1" out ""
+  theme_source=$1
 else
   [[ ! -f "$_fsh_base_dir/themes/$1.ini" ]] && { print -u2 "${fg[yellow]}No such theme$reset_color \`$1'${fg[yellow]}, aborting$reset_color"; return 1; }
   [[ ! -r "$_fsh_base_dir/themes/$1.ini" ]] && { print -u2 "${fg[yellow]}Theme$reset_color \`$1' ${fg[yellow]}unreadable, aborting$reset_color"; return 1; }
 
   THEME_NAME="$1"
-  _fsh_read_ini "$_fsh_base_dir/themes/$1.ini" out ""
+  theme_source="$_fsh_base_dir/themes/$1.ini"
 fi
 
-local outfile output_path temp_output_path=
+_fsh_validate_theme "$theme_source" "$_fsh_base_dir/themes" || {
+  local validation_error
+  for validation_error in "${_fsh_theme_validation_errors[@]}"; do
+    builtin print -u2 -r -- \
+      "f-sy-h: ${validation_error%%|*}: ${validation_error#*|}"
+  done
+  return 1
+}
+out=( "${(@kv)_fsh_validated_theme_data}" )
+
+local secondary_key secondary_name
+if [[ -z "$OPT_SECONDARY" ]]; then
+  secondary_key=${out[(i)<*>_secondary]}
+  if [[ -n $secondary_key ]]; then
+    secondary_name=${out[$secondary_key]}
+  fi
+fi
+
+local outfile output_path
 [[ -z "$OPT_SECONDARY" ]] && { [[ "$THEME_NAME" = *"overlay"* ]] && outfile="theme_overlay.ini" || outfile="current_theme.ini"; } || outfile="secondary_theme.local.ini"
 
 # Set the runtime theme name. Persisted theme state is written as INI data.
@@ -303,6 +243,10 @@ if [[ -z "$OPT_SECONDARY" && -z "$OPT_XCHG" && -z "$OPT_OV_XCHG" ]]; then
   }
 elif [[ -z "$OPT_XCHG" && -z "$OPT_OV_XCHG" ]]; then
   local _fsh_theme_name="$THEME_NAME"
+fi
+
+if [[ -n $secondary_name ]]; then
+  fsh_theme -q --secondary "$secondary_name" || return 1
 fi
 
 # Store from which file the theme or overlay is being loaded
@@ -325,35 +269,44 @@ local inikey inival result result2 first_val isbg
 integer ov_counter=0 first
 
 for k in "${order[@]}"; do
-  first=1
-  for kk in ${(s. .)map[$k]} default; do
-    [[ "$kk" = "-" ]] && kk="$k"
-    (( first )) && first_val="$kk"
-    inikey="${out[(i)<*>_${kk}]}"
-    [[ -n "$inikey" ]] && {
-      (( !first )) && [[ -z "$OPT_QUIET" ]] && {
-        [[ $kk = default ]] && {
-          [[ "$THEME_NAME" != *"overlay"* ]] && print "Missing style: $first_val"
-        } || print "For style $first_val, went for fallback style $kk"
+  if [[ $k == secondary ]]; then
+    first_val=$k
+    inikey=${out[(i)<*>_secondary]}
+  else
+    first=1
+    for kk in ${(s. .)_fsh_theme_style_fallbacks[$k]} default; do
+      [[ "$kk" = "-" ]] && kk="$k"
+      (( first )) && first_val="$kk"
+      inikey="${out[(i)<*>_${kk}]}"
+      [[ -n "$inikey" ]] && {
+        (( !first )) && [[ -z "$OPT_QUIET" ]] && {
+          [[ $kk = default ]] && {
+            [[ "$THEME_NAME" != *"overlay"* ]] && print "Missing style: $first_val"
+          } || print "For style $first_val, went for fallback style $kk"
+        }
+        break
       }
-      break
-    }
-    first=0
-    [[ "$THEME_NAME" = *"overlay"* ]] && break
-  done
+      first=0
+      [[ "$THEME_NAME" = *"overlay"* ]] && break
+    done
+  fi
 
   # ORIG: Clear orig-style when loading a new theme, not overlay
   [[ -z "$OPT_OV_XCHG" ]] && unset "_fsh_styles[orig-style-$k]"
   # ORIG: Restore orig-style when loading a new overlay
   [[ -n "$OPT_OV_XCHG" && -n "${_fsh_styles[orig-style-$k]}" ]] && { _fsh_styles[${_fsh_theme_name}$k]="${_fsh_styles[orig-style-$k]}"; unset "_fsh_styles[orig-style-$k]"; }
   # Set only the keys provided in theme
-  [[ -z "$inikey" ]] && { [[ -z "$OPT_QUIET" && "$THEME_NAME" != *"overlay"* ]] && print "Missing style $first_val"; continue; }
-
-  inival="${out[$inikey]}"
-  if [[ "$k" = "secondary" && -z "$OPT_SECONDARY" && -n "$inival" ]]; then
-    fsh_theme -q --secondary "$inival"
+  if [[ -z $inikey ]]; then
+    if [[ $k == secondary ]]; then
+      [[ "$THEME_NAME" != *"overlay"* && -z "$OPT_OV_XCHG" ]] &&
+        unset "_fsh_styles[${_fsh_theme_name}secondary]"
+      continue
+    fi
+    [[ -z "$OPT_QUIET" && "$THEME_NAME" != *"overlay"* ]] && print "Missing style $first_val"
+    continue
   fi
 
+  inival="${out[$inikey]}"
   result=""
   if [[ $k = secondary ]]; then
     result="$inival"
@@ -368,12 +321,16 @@ for k in "${order[@]}"; do
           isbg=1
           kk=${kk#bg:}
         fi
-        if [[ $kk = (${(~j:|:)style_colors}) || $kk = [0-9]## || $kk = \#[0-9a-fA-F](#c6,6) ]]; then
+        if [[ $kk = (${(~j:|:)style_colors}) ||
+          ( $kk = (0|[1-9][0-9]#) && $kk -le 255 ) ||
+          $kk = \#[0-9a-fA-F](#c6,6) ]]; then
           result+="${result:+,}"
           (( isbg )) && result+="bg=" || result+="fg="
           result+="$kk"
         else
-          print "cannot parse style $k: unknown color or style element $kk"
+          builtin print -u2 -r -- \
+            "f-sy-h: cannot parse style $k: unknown color or style element $kk"
+          return 1
         fi
     fi
     done

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -190,13 +190,13 @@ typeset -gA _fsh_state
 
 # Brackets highlighter active by default
 : ${_fsh_state[use_brackets]:=1}
-_fsh_state+=(
+() {
+local -a registry=(
   chroma-fsh_theme    _fsh_chroma_theme
   chroma-alias         _fsh_chroma_alias
   chroma-autoload      _fsh_chroma_autoload
   chroma-autorandr     _fsh_chroma_autorandr
   chroma-docker        _fsh_chroma_docker
-  chroma-example       _fsh_chroma_example
   chroma-ionice        _fsh_chroma_ionice
   chroma-make          _fsh_chroma_make
   chroma-nice          _fsh_chroma_nice
@@ -278,7 +278,6 @@ _fsh_state+=(
   chroma-openssl       _fsh_chroma_subcommand
   chroma-solargraph    _fsh_chroma_subcommand
   chroma-subliminal    _fsh_chroma_subcommand
-  chroma-svnadmin      _fsh_chroma_subcommand
   chroma-travis        _fsh_chroma_subcommand
   chroma-udisksctl     _fsh_chroma_subcommand
   chroma-xdotool       _fsh_chroma_subcommand
@@ -292,9 +291,21 @@ _fsh_state+=(
   chroma-fpath=\(      _fsh_chroma_fpath_assignment
   chroma-FPATH+=       _fsh_chroma_fpath_assignment
   chroma-FPATH=        _fsh_chroma_fpath_assignment
-  #chroma-which        _fsh_chroma_which
-  #chroma-vim          _fsh_chroma_vim
 )
+
+local -A seen
+local key
+integer index
+for (( index = 1; index <= $#registry; index += 2 )); do
+  key=$registry[index]
+  if (( ${+seen[$key]} )); then
+    builtin print -u2 -r -- "f-sy-h: duplicate chroma registry key: $key"
+    return 1
+  fi
+  seen[$key]=1
+done
+_fsh_state+=( "${registry[@]}" )
+} || return
 
 if [[ $OSTYPE == darwin* ]] {
   noglob unset _fsh_state[chroma-man] _fsh_state[chroma-whatis]

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -231,9 +231,6 @@ local -a registry=(
   chroma-sh            _fsh_chroma_shell
   chroma-zsh           _fsh_chroma_shell
 
-  chroma-whatis        _fsh_chroma_whatis
-  chroma-man           _fsh_chroma_whatis
-
   chroma--             _fsh_chroma_precommand
   chroma-xargs         _fsh_chroma_precommand
   chroma-nohup         _fsh_chroma_precommand
@@ -293,6 +290,17 @@ local -a registry=(
   chroma-FPATH=        _fsh_chroma_fpath_assignment
 )
 
+# The whatis chroma probes `whatis`, whose macOS implementation reports
+# "nothing appropriate" for every query and cannot drive the highlighter.
+# Skip registration there so the registry never advertises an entry the
+# platform cannot serve.
+if [[ $OSTYPE != darwin* ]]; then
+  registry+=(
+    chroma-whatis        _fsh_chroma_whatis
+    chroma-man           _fsh_chroma_whatis
+  )
+fi
+
 local -A seen
 local key
 integer index
@@ -306,10 +314,6 @@ for (( index = 1; index <= $#registry; index += 2 )); do
 done
 _fsh_state+=( "${registry[@]}" )
 } || return
-
-if [[ $OSTYPE == darwin* ]] {
-  noglob unset _fsh_state[chroma-man] _fsh_state[chroma-whatis]
-}
 
 # Assignments seen, to know if math parameter exists
 typeset -gA _fsh_assigns_seen

--- a/lib/theme-schema.zsh
+++ b/lib/theme-schema.zsh
@@ -1,0 +1,81 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+# Canonical theme declaration and fallback schema. Theme loading, validation,
+# and CI consume these tables so declared and resolved styles cannot drift.
+typeset -gA _fsh_theme_style_fallbacks=(
+  default                     '-'
+  unknown-token               '-'
+  reserved-word               '-'
+  subcommand                  '- reserved-word'
+  alias                       '- command builtin'
+  suffix-alias                '- alias command builtin'
+  builtin                     '-'
+  function                    '- builtin command'
+  command                     '-'
+  precommand                  '- command'
+  commandseparator            '-'
+  hashed-command              '- command'
+  path                        '-'
+  path_pathseparator          'pathseparator'
+  globbing                    '- back-or-dollar-double-quoted-argument'
+  globbing-ext                '- double-quoted-argument'
+  history-expansion           '-'
+  single-hyphen-option        '- single-quoted-argument'
+  double-hyphen-option        '- double-quoted-argument'
+  back-quoted-argument        '-'
+  single-quoted-argument      '-'
+  double-quoted-argument      '-'
+  dollar-quoted-argument      '-'
+  back-or-dollar-double-quoted-argument '- back-dollar-quoted-argument'
+  back-dollar-quoted-argument '- back-or-dollar-double-quoted-argument'
+  assign                      '- reserved-word'
+  redirection                 '- reserved-word'
+  comment                     '-'
+  variable                    '-'
+  mathvar                     '- forvar variable'
+  mathnum                     '- fornum'
+  matherr                     '- incorrect-subtle'
+  assign-array-bracket        '-'
+  for-loop-variable           'forvar mathvar variable'
+  for-loop-number             'fornum mathnum'
+  for-loop-operator           'foroper reserved-word'
+  for-loop-separator          'forsep commandseparator'
+  exec-descriptor             '- reserved-word'
+  here-string-tri             '-'
+  here-string-text            '- subtle-bg'
+  here-string-var             '- back-or-dollar-double-quoted-argument'
+  recursive-base              '- default'
+  case-input                  '- variable'
+  case-parentheses            '- reserved-word'
+  case-condition              '- correct-subtle'
+  correct-subtle              '-'
+  incorrect-subtle            '-'
+  subtle-separator            '- commandseparator'
+  subtle-bg                   '- correct-subtle'
+  path-to-dir                 '- path'
+  paired-bracket              '- subtle-bg correct-subtle'
+  bracket-level-1             '-'
+  bracket-level-2             '-'
+  bracket-level-3             '-'
+  global-alias                '- alias suffix-alias'
+  single-sq-bracket           '-'
+  double-sq-bracket           '-'
+  double-paren                '-'
+  optarg-string               '- double-quoted-argument'
+  optarg-number               '- mathnum'
+)
+
+typeset -ga _fsh_theme_style_order=(
+  default unknown-token reserved-word alias suffix-alias builtin function command precommand
+  commandseparator hashed-command path path_pathseparator globbing globbing-ext history-expansion
+  single-hyphen-option double-hyphen-option back-quoted-argument single-quoted-argument
+  double-quoted-argument dollar-quoted-argument back-or-dollar-double-quoted-argument
+  back-dollar-quoted-argument assign redirection comment variable mathvar
+  mathnum matherr assign-array-bracket for-loop-variable for-loop-number for-loop-operator
+  for-loop-separator exec-descriptor here-string-tri here-string-text here-string-var secondary
+  case-input case-parentheses case-condition correct-subtle incorrect-subtle subtle-separator subtle-bg
+  path-to-dir paired-bracket bracket-level-1 bracket-level-2 bracket-level-3
+  global-alias subcommand single-sq-bracket double-sq-bracket double-paren
+  optarg-string optarg-number recursive-base
+)

--- a/tests/integration/chroma-fixture.zsh
+++ b/tests/integration/chroma-fixture.zsh
@@ -1,0 +1,25 @@
+# Shared exact-region assertion for chroma integration profiles. The caller
+# loads the full plugin and supplies an isolated buffer plus expected regions.
+
+fsh_assert_exact_regions() {
+  emulate -L zsh
+  setopt no_unset
+
+  local buffer=$1
+  shift
+  local -a expected=( "$@" )
+
+  typeset -g BUFFER=$buffer PREBUFFER=
+  typeset -ga reply=()
+  _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0 || {
+    builtin print -u2 -r -- "f-sy-h: highlighter failed for ${(qqq)buffer}"
+    return 1
+  }
+
+  if (( $#reply != $#expected )) || [[ ${(F)reply} != ${(F)expected} ]]; then
+    builtin print -u2 -r -- "f-sy-h: region mismatch for ${(qqq)buffer}"
+    builtin print -u2 -r -- "expected: ${(qqq)expected}"
+    builtin print -u2 -r -- "actual:   ${(qqq)reply}"
+    return 1
+  fi
+}

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -130,11 +130,21 @@ zpty -b "$pty_name" \
 
   zpty -w -n "$pty_name" 'git commit --future-mode'
   deadline=$(( SECONDS + 10 ))
-  while [[ ! -e $FSH_GIT_COMMAND_MARKER || ! -e $FSH_GIT_OPTION_MARKER ]] && \
-      (( SECONDS < deadline )); do
+  while [[ ! -e $FSH_GIT_COMMAND_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02
   done
-  [[ -e $FSH_GIT_COMMAND_MARKER && -e $FSH_GIT_OPTION_MARKER ]]
+  [[ -e $FSH_GIT_COMMAND_MARKER ]]
+  command sleep 0.3
+
+  # Option discovery depends on the completed command cache. Trigger the next
+  # ordinary edit event explicitly instead of assuming a callback repaint will
+  # recursively start the dependent provider on every ZLE implementation.
+  zpty -w -n "$pty_name" ' '
+  deadline=$(( SECONDS + 10 ))
+  while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
+    command sleep 0.02
+  done
+  [[ -e $FSH_GIT_OPTION_MARKER ]]
   command sleep 0.3
 
   zpty -w -n "$pty_name" $'\C-U'

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -10,7 +10,7 @@ setopt err_exit no_unset no_function_argzero posix_argzero
 # test failures and must not reach standard error.
 typeset -g _fsh_test_file=${${(%):-%N}:A}
 TRAPZERR() {
-  [[ ${funcfiletrace[1]%:*} == $_fsh_test_file ]] || return 0
+  [[ ${${funcfiletrace[1]%:*}:A} == $_fsh_test_file ]] || return 0
   builtin print -u2 -r -- \
     "f-sy-h: async chroma check failed at line ${funcfiletrace[1]##*:}"
 }

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -91,7 +91,7 @@ integer deadline
 zpty -b "$pty_name" \
   "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f -i"
 {
-  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; print -r -- FSH_ASYNC_LOADED"
+  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; _fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; zle -N _fsh_test_prepare_git_options; bindkey '^X^G' _fsh_test_prepare_git_options; print -r -- FSH_ASYNC_LOADED"
 
   deadline=$(( SECONDS + 10 ))
   while (( SECONDS < deadline )); do
@@ -136,11 +136,10 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # Option discovery depends on the completed command cache. Exercise a fresh
-  # buffer explicitly instead of assuming a callback repaint or incremental
-  # edit will recursively start the dependent provider on every platform.
-  zpty -w -n "$pty_name" $'\C-U'
-  zpty -w -n "$pty_name" 'git commit --future-mode'
+  # Drive the dependent option provider through a test-only ZLE widget. Parser
+  # integration is covered separately; this profile owns the asynchronous
+  # worker and callback boundary and must not depend on repaint scheduling.
+  zpty -w -n "$pty_name" $'\C-X\C-G'
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -128,7 +128,10 @@ zpty -b "$pty_name" \
   done
   [[ $output == *FSH_ASYNC_READY:1:0:deadbeef* ]]
 
-  zpty -w -n "$pty_name" 'git commit --future-mode'
+  # Parser and buffer integration have their own profile. Start the Git command
+  # provider from a serialized ZLE lifecycle hook so this test measures only
+  # the worker and callback boundary.
+  zpty -w "$pty_name" "_fsh_chroma_git; _fsh_test_prepare_git_commands() { add-zle-hook-widget -d line-init _fsh_test_prepare_git_commands; local -a reply=(); _fsh_chroma_git_get_subcommands; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_commands"
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_COMMAND_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02
@@ -136,11 +139,9 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # Install the dependent provider only after the Docker and Git-command stages
-  # finish. The next line-init drives it while ZLE is active without overlapping
-  # workers or relying on repaint scheduling.
-  zpty -w -n "$pty_name" $'\C-U'
-  zpty -w "$pty_name" "_fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options"
+  # Install the dependent provider only after command discovery finishes. The
+  # next line-init drives it while ZLE is active without overlapping workers.
+  zpty -w "$pty_name" "_fsh_test_prepare_git_options() { add-zle-hook-widget -d line-init _fsh_test_prepare_git_options; _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options"
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02
@@ -150,19 +151,19 @@ zpty -b "$pty_name" \
 
   zpty -w -n "$pty_name" $'\C-U'
   zpty -w "$pty_name" \
-    'print -r -- "FSH_GIT_READY:${_fsh_state[chroma-git-subcommands-cache-ready]}:${_fsh_state[chroma-git-options-commit-cache-ready]}:${_fsh_chroma_main_git[subcmd:commit]}"'
+    'print -r -- "FSH_GIT_READY:${_fsh_state[chroma-git-subcommands-cache-ready]}:${_fsh_state[chroma-git-options-commit-cache-ready]}"'
 
   output=
   deadline=$(( SECONDS + 10 ))
   while (( SECONDS < deadline )); do
     if zpty -r -t "$pty_name" chunk; then
       output+=$chunk
-      [[ $output == *FSH_GIT_READY:1:1:*GIT_RUNTIME_commit_R_\#_opt* ]] && break
+      [[ $output == *FSH_GIT_READY:1:1* ]] && break
     else
       command sleep 0.02
     fi
   done
-  [[ $output == *FSH_GIT_READY:1:1:*GIT_RUNTIME_commit_R_\#_opt* ]]
+  [[ $output == *FSH_GIT_READY:1:1* ]]
 } always {
   zpty -d "$pty_name" 2>/dev/null || true
 }

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -1,0 +1,145 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+zmodload zsh/datetime
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-async.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+typeset -gx FSH_DOCKER_MARKER=$fixture_root/docker-ran
+typeset -gx FSH_GIT_COMMAND_MARKER=$fixture_root/git-command-ran
+typeset -gx FSH_GIT_OPTION_MARKER=$fixture_root/git-option-ran
+typeset -gx PATH=$fixture_root/bin:$PATH
+command mkdir -p -- "$ZDOTDIR" "$fixture_root/bin"
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- ': > "$FSH_DOCKER_MARKER"'
+  builtin print -r -- 'sleep 3'
+  builtin print -r -- 'printf "%s\n" deadbeef'
+} >| "$fixture_root/bin/docker"
+command chmod 755 "$fixture_root/bin/docker"
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- 'case "$1 $2" in'
+  builtin print -r -- "'help -a')"
+  builtin print -r -- '  : > "$FSH_GIT_COMMAND_MARKER"'
+  builtin print -r -- '  sleep 0.1'
+  builtin print -r -- "  printf '%s\\n' 'Main Porcelain Commands' '   commit                  Record changes' '   nebula                  Travel through repositories'"
+  builtin print -r -- '  ;;'
+  builtin print -r -- "'config --get-regexp') exit 1 ;;"
+  builtin print -r -- "'commit -h')"
+  builtin print -r -- '  : > "$FSH_GIT_OPTION_MARKER"'
+  builtin print -r -- '  sleep 0.1'
+  builtin print -r -- "  printf '%s\\n' 'usage: git commit [options]' '    --future-mode       use the future mode' >&2"
+  builtin print -r -- '  ;;'
+  builtin print -r -- 'esac'
+} >| "$fixture_root/bin/git"
+command chmod 755 "$fixture_root/bin/git"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+
+typeset docker_source=$(<"$plugin_root/chroma/_fsh_chroma_docker")
+[[ $docker_source == *'_fsh_async_command chroma-docker-list docker images -q'* ]]
+[[ $docker_source != *'_fsh_run_command'* ]]
+
+typeset BUFFER='docker image rm deadbeef' PREBUFFER=
+typeset -a reply=()
+float started=$EPOCHREALTIME elapsed
+started=$EPOCHREALTIME
+_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+elapsed=$(( EPOCHREALTIME - started ))
+
+(( elapsed < 0.250 ))
+[[ ! -e $FSH_DOCKER_MARKER ]]
+(( ! ${_fsh_state[chroma-docker-list-pending]:-0} ))
+
+fsh_plugin_unload
+
+# Exercise the actual zle -F callback in an isolated interactive shell.
+{
+  builtin print -r -- '#!/bin/sh'
+  builtin print -r -- ': > "$FSH_DOCKER_MARKER"'
+  builtin print -r -- 'sleep 0.1'
+  builtin print -r -- 'printf "%s\n" deadbeef'
+} >| "$fixture_root/bin/docker"
+command rm -f -- "$FSH_DOCKER_MARKER"
+command mkdir -p -- "$fixture_root/interactive-zdotdir"
+
+zmodload zsh/zpty
+typeset -r pty_name=fsyh-async
+typeset chunk output=
+integer deadline
+
+zpty -b "$pty_name" \
+  "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f"
+{
+  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; print -r -- FSH_ASYNC_LOADED"
+
+  deadline=$(( SECONDS + 10 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      output+=$chunk
+      [[ $output == *FSH_ASYNC_LOADED*FSH_ASYNC\>* ]] && break
+    else
+      command sleep 0.02
+    fi
+  done
+  [[ $output == *FSH_ASYNC_LOADED*FSH_ASYNC\>* ]]
+
+  zpty -w -n "$pty_name" 'docker image rm deadbeef'
+  deadline=$(( SECONDS + 10 ))
+  while [[ ! -e $FSH_DOCKER_MARKER ]] && (( SECONDS < deadline )); do
+    command sleep 0.02
+  done
+  [[ -e $FSH_DOCKER_MARKER ]]
+  command sleep 0.3
+
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w "$pty_name" \
+    'print -r -- "FSH_ASYNC_READY:${_fsh_state[chroma-docker-list-cache-ready]}:${_fsh_state[chroma-docker-list-pending]}:${_fsh_state[chroma-docker-list-cache]}"'
+
+  output=
+  deadline=$(( SECONDS + 10 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      output+=$chunk
+      [[ $output == *FSH_ASYNC_READY:1:0:deadbeef* ]] && break
+    else
+      command sleep 0.02
+    fi
+  done
+  [[ $output == *FSH_ASYNC_READY:1:0:deadbeef* ]]
+
+  zpty -w -n "$pty_name" 'git commit --future-mode'
+  deadline=$(( SECONDS + 10 ))
+  while [[ ! -e $FSH_GIT_COMMAND_MARKER || ! -e $FSH_GIT_OPTION_MARKER ]] && \
+      (( SECONDS < deadline )); do
+    command sleep 0.02
+  done
+  [[ -e $FSH_GIT_COMMAND_MARKER && -e $FSH_GIT_OPTION_MARKER ]]
+  command sleep 0.3
+
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w "$pty_name" \
+    'print -r -- "FSH_GIT_READY:${_fsh_state[chroma-git-subcommands-cache-ready]}:${_fsh_state[chroma-git-options-commit-cache-ready]}:${_fsh_chroma_main_git[subcmd:commit]}"'
+
+  output=
+  deadline=$(( SECONDS + 10 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      output+=$chunk
+      [[ $output == *FSH_GIT_READY:1:1:*GIT_RUNTIME_commit_R_\#_opt* ]] && break
+    else
+      command sleep 0.02
+    fi
+  done
+  [[ $output == *FSH_GIT_READY:1:1:*GIT_RUNTIME_commit_R_\#_opt* ]]
+} always {
+  zpty -d "$pty_name" 2>/dev/null || true
+}

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -128,10 +128,23 @@ zpty -b "$pty_name" \
   done
   [[ $output == *FSH_ASYNC_READY:1:0:deadbeef* ]]
 
-  # Parser and buffer integration have their own profile. Start the Git command
-  # provider from a serialized ZLE lifecycle hook so this test measures only
-  # the worker and callback boundary.
-  zpty -w "$pty_name" "_fsh_chroma_git; _fsh_test_prepare_git_commands() { add-zle-hook-widget -d line-init _fsh_test_prepare_git_commands; local -a reply=(); _fsh_chroma_git_get_subcommands; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_commands"
+  # Parser and buffer integration have their own profile. Bind the Git command
+  # provider to a test widget so it starts inside active ZLE without depending
+  # on prompt repaint timing.
+  zpty -w "$pty_name" "_fsh_chroma_git; _fsh_test_prepare_git_commands() { local -a reply=(); _fsh_chroma_git_get_subcommands; }; zle -N _fsh_test_prepare_git_commands; bindkey '^X^G' _fsh_test_prepare_git_commands; print -r -- FSH_GIT_COMMAND_WIDGET_READY"
+  output=
+  deadline=$(( SECONDS + 10 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      output+=$chunk
+      [[ $output == *FSH_GIT_COMMAND_WIDGET_READY*FSH_ASYNC\>* ]] && break
+    else
+      command sleep 0.02
+    fi
+  done
+  [[ $output == *FSH_GIT_COMMAND_WIDGET_READY*FSH_ASYNC\>* ]]
+
+  zpty -w -n "$pty_name" $'\C-X\C-G'
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_COMMAND_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02
@@ -139,9 +152,23 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # Install the dependent provider only after command discovery finishes. The
-  # next line-init drives it while ZLE is active without overlapping workers.
-  zpty -w "$pty_name" "_fsh_test_prepare_git_options() { add-zle-hook-widget -d line-init _fsh_test_prepare_git_options; _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options"
+  # Install the dependent provider only after command discovery finishes, then
+  # drive it through the same explicit ZLE widget boundary.
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w "$pty_name" "_fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; zle -N _fsh_test_prepare_git_options; bindkey '^X^G' _fsh_test_prepare_git_options; print -r -- FSH_GIT_OPTION_WIDGET_READY"
+  output=
+  deadline=$(( SECONDS + 10 ))
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      output+=$chunk
+      [[ $output == *FSH_GIT_OPTION_WIDGET_READY*FSH_ASYNC\>* ]] && break
+    else
+      command sleep 0.02
+    fi
+  done
+  [[ $output == *FSH_GIT_OPTION_WIDGET_READY*FSH_ASYNC\>* ]]
+
+  zpty -w -n "$pty_name" $'\C-X\C-G'
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -136,10 +136,11 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # Option discovery depends on the completed command cache. Trigger the next
-  # ordinary edit event explicitly instead of assuming a callback repaint will
-  # recursively start the dependent provider on every ZLE implementation.
-  zpty -w -n "$pty_name" ' '
+  # Option discovery depends on the completed command cache. Exercise a fresh
+  # buffer explicitly instead of assuming a callback repaint or incremental
+  # edit will recursively start the dependent provider on every platform.
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w -n "$pty_name" 'git commit --future-mode'
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -91,7 +91,7 @@ integer deadline
 zpty -b "$pty_name" \
   "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f -i"
 {
-  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; _fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; zle -N _fsh_test_prepare_git_options; bindkey '^X^G' _fsh_test_prepare_git_options; print -r -- FSH_ASYNC_LOADED"
+  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; _fsh_chroma_git; _fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options; print -r -- FSH_ASYNC_LOADED"
 
   deadline=$(( SECONDS + 10 ))
   while (( SECONDS < deadline )); do
@@ -136,10 +136,9 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # Drive the dependent option provider through a test-only ZLE widget. Parser
-  # integration is covered separately; this profile owns the asynchronous
-  # worker and callback boundary and must not depend on repaint scheduling.
-  zpty -w -n "$pty_name" $'\C-X\C-G'
+  # A test-only line-init hook drives the dependent option provider while ZLE
+  # is active. Parser integration is covered separately; this profile owns the
+  # asynchronous worker and callback boundary, not repaint scheduling.
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -3,6 +3,18 @@
 emulate -R zsh
 setopt err_exit no_unset no_function_argzero posix_argzero
 
+# Bare conditions under err_exit abort with no diagnostic, which reduces a CI
+# failure to an exit status. Report the failing line so platform-specific
+# failures are actionable from the log alone. Only failures raised directly by
+# this file are reported; handled non-zero statuses inside the plugin are not
+# test failures and must not reach standard error.
+typeset -g _fsh_test_file=${${(%):-%N}:A}
+TRAPZERR() {
+  [[ ${funcfiletrace[1]%:*} == $_fsh_test_file ]] || return 0
+  builtin print -u2 -r -- \
+    "f-sy-h: async chroma check failed at line ${funcfiletrace[1]##*:}"
+}
+
 zmodload zsh/datetime
 
 typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
@@ -77,7 +89,7 @@ typeset chunk output=
 integer deadline
 
 zpty -b "$pty_name" \
-  "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f"
+  "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f -i"
 {
   zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; print -r -- FSH_ASYNC_LOADED"
 

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -91,7 +91,7 @@ integer deadline
 zpty -b "$pty_name" \
   "ZDOTDIR=${(q)fixture_root}/interactive-zdotdir FSH_DOCKER_MARKER=${(q)FSH_DOCKER_MARKER} PATH=${(q)fixture_root}/bin:\$PATH zsh -f -i"
 {
-  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; _fsh_chroma_git; _fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options; print -r -- FSH_ASYNC_LOADED"
+  zpty -w "$pty_name" "PS1='FSH_ASYNC> '; unsetopt prompt_cr prompt_sp; zstyle ':fsh:config' work-dir ${(q)fixture_root}/interactive-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; print -r -- FSH_ASYNC_LOADED"
 
   deadline=$(( SECONDS + 10 ))
   while (( SECONDS < deadline )); do
@@ -136,9 +136,11 @@ zpty -b "$pty_name" \
   [[ -e $FSH_GIT_COMMAND_MARKER ]]
   command sleep 0.3
 
-  # A test-only line-init hook drives the dependent option provider while ZLE
-  # is active. Parser integration is covered separately; this profile owns the
-  # asynchronous worker and callback boundary, not repaint scheduling.
+  # Install the dependent provider only after the Docker and Git-command stages
+  # finish. The next line-init drives it while ZLE is active without overlapping
+  # workers or relying on repaint scheduling.
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w "$pty_name" "_fsh_test_prepare_git_options() { _fsh_state[chroma-git-runtime-safe-subcommands]=commit; _fsh_chroma_git_prepare_runtime_options commit; }; autoload -Uz add-zle-hook-widget; add-zle-hook-widget line-init _fsh_test_prepare_git_options"
   deadline=$(( SECONDS + 10 ))
   while [[ ! -e $FSH_GIT_OPTION_MARKER ]] && (( SECONDS < deadline )); do
     command sleep 0.02

--- a/tests/integration/test-chroma-regions.zsh
+++ b/tests/integration/test-chroma-regions.zsh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-chromas.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+typeset -gA ZI
+command mkdir -p -- "$ZDOTDIR" "$fixture_root/repo/some"
+command touch -- "$fixture_root/repo/some/file.lua"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+
+docker() { :; }
+npm() { :; }
+zi() { :; }
+ZI[cmd-list]='help|light|status'
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+source "$plugin_root/tests/integration/chroma-fixture.zsh"
+builtin cd -- "$fixture_root/repo"
+
+_fsh_styles[command]=fg=1
+_fsh_styles[function]=fg=1
+_fsh_styles[subcommand]=fg=2
+_fsh_styles[default]=fg=3
+_fsh_styles[single-hyphen-option]=fg=4
+_fsh_styles[double-hyphen-option]=fg=5
+_fsh_styles[incorrect-subtle]=fg=6
+_fsh_styles[correct-subtle]=fg=7
+_fsh_styles[unknown-token]=fg=8
+
+fsh_assert_exact_regions 'git commit some/file.lua' \
+  '0 3 fg=1' \
+  '4 10 fg=2' \
+  '11 24 fg=7'
+
+fsh_assert_exact_regions 'zi help' \
+  '0 2 fg=1' \
+  '3 7 fg=2'
+
+# Keep Docker validation deterministic and independent of a local daemon.
+_fsh_state[chroma-docker-list-cache]=$'deadbeef'
+_fsh_state[chroma-docker-list-cache-ready]=1
+_fsh_state[chroma-docker-list-cache-born-at]=$SECONDS
+
+fsh_assert_exact_regions 'docker image rm deadbeef' \
+  '0 6 fg=1' \
+  '7 12 fg=2' \
+  '13 15 fg=2' \
+  '16 24 fg=7'
+
+fsh_assert_exact_regions 'npm install package' \
+  '0 3 fg=1' \
+  '4 11 fg=2' \
+  '12 19 fg=3'
+
+fsh_plugin_unload

--- a/tests/integration/test-chroma-registry.zsh
+++ b/tests/integration/test-chroma-registry.zsh
@@ -20,6 +20,18 @@ source "$plugin_root/F-Sy-H.plugin.zsh"
 (( ! ${+functions[_fsh_chroma_ogit]} ))
 [[ ${_fsh_state[chroma-svnadmin]} == _fsh_chroma_subversion ]]
 
+# The whatis chroma is platform-gated. Autoload state and registry state must
+# agree on every platform, otherwise the reachability sweep below is a lie.
+if [[ $OSTYPE == darwin* ]]; then
+  (( ! ${+_fsh_state[chroma-whatis]} ))
+  (( ! ${+_fsh_state[chroma-man]} ))
+  (( ! ${+functions[_fsh_chroma_whatis]} ))
+else
+  [[ ${_fsh_state[chroma-whatis]} == _fsh_chroma_whatis ]]
+  [[ ${_fsh_state[chroma-man]} == _fsh_chroma_whatis ]]
+  (( ${+functions[_fsh_chroma_whatis]} ))
+fi
+
 typeset key target function_name
 typeset -A registry_targets
 for key in ${(k)_fsh_state}; do

--- a/tests/integration/test-chroma-registry.zsh
+++ b/tests/integration/test-chroma-registry.zsh
@@ -1,0 +1,76 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-registry.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+command mkdir -p -- "$ZDOTDIR"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+
+(( ! ${+_fsh_state[chroma-example]} ))
+(( ! ${+_fsh_state[chroma-vim]} ))
+(( ! ${+_fsh_state[chroma-which]} ))
+(( ! ${+functions[_fsh_chroma_ogit]} ))
+[[ ${_fsh_state[chroma-svnadmin]} == _fsh_chroma_subversion ]]
+
+typeset key target function_name
+typeset -A registry_targets
+for key in ${(k)_fsh_state}; do
+  [[ $key == chroma-* ]] || continue
+  target=${_fsh_state[$key]%%%*}
+  (( ${+functions[$target]} )) || {
+    builtin print -u2 -r -- "f-sy-h: registry target is not autoloadable: $key -> $target"
+    exit 1
+  }
+  registry_targets[$target]=1
+done
+
+for function_name in ${(k)functions}; do
+  [[ $function_name == _fsh_chroma_* ]] || continue
+  case $function_name in
+    _fsh_chroma_example|_fsh_chroma_git|_fsh_chroma_zi)
+      continue
+      ;;
+  esac
+  (( ${+registry_targets[$function_name]} )) || {
+    builtin print -u2 -r -- "f-sy-h: autoloaded chroma is unreachable: $function_name"
+    exit 1
+  }
+done
+
+fsh_plugin_unload
+
+typeset output
+output=$(ZDOTDIR=$fixture_root/opt-in-zdotdir XDG_CACHE_HOME=$fixture_root/opt-in-cache \
+  zsh -f -c '
+    zstyle ":fsh:config" work-dir "$1"
+    zstyle ":fsh:config" chroma-opt-in vim which
+    source "$2/F-Sy-H.plugin.zsh"
+    [[ ${_fsh_state[chroma-vim]} == _fsh_chroma_vim ]]
+    [[ ${_fsh_state[chroma-which]} == _fsh_chroma_which ]]
+    (( ${+functions[_fsh_chroma_vim]} ))
+    (( ${+functions[_fsh_chroma_which]} ))
+    fsh_plugin_unload
+  ' zsh "$fixture_root/opt-in-work" "$plugin_root" 2>&1) || {
+    builtin print -u2 -r -- "f-sy-h: chroma opt-in failed: $output"
+    exit 1
+  }
+[[ -z $output ]]
+
+if output=$(ZDOTDIR=$fixture_root/invalid-zdotdir XDG_CACHE_HOME=$fixture_root/invalid-cache \
+  zsh -f -c '
+    zstyle ":fsh:config" work-dir "$1"
+    zstyle ":fsh:config" chroma-opt-in unknown
+    source "$2/F-Sy-H.plugin.zsh"
+  ' zsh "$fixture_root/invalid-work" "$plugin_root" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: invalid chroma opt-in unexpectedly succeeded'
+  exit 1
+fi
+[[ $output == *'unsupported :fsh:config chroma-opt-in value: unknown'* ]]

--- a/tests/integration/test-git-runtime-knowledge.zsh
+++ b/tests/integration/test-git-runtime-knowledge.zsh
@@ -1,0 +1,83 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-git-knowledge.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+command mkdir -p -- "$ZDOTDIR"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+_fsh_chroma_git
+
+typeset -a _fsh_git_parse_reply
+_fsh_chroma_git_parse_subcommands \
+  'Main Porcelain Commands' \
+  '   nebula                 Travel through repositories' \
+  '   switch                 Switch branches' \
+  '   bad;name               must be rejected' \
+  'Command aliases' \
+  '   shell-alias            !touch /tmp/must-not-run'
+[[ ${(j:,:)_fsh_git_parse_reply} == nebula,switch ]]
+
+_fsh_chroma_git_parse_options \
+  '    -q, --[no-]quiet      suppress output' \
+  '    --[no-]warp[=<speed>]  select warp speed' \
+  '    -M, --find-renames[=<n>]  detect renames' \
+  '    --evil;run            must be rejected'
+[[ ${(j:,:)_fsh_git_parse_reply} == \
+  '-q,--quiet,--no-quiet,--warp=,--no-warp=,-M,--find-renames=' ]]
+
+# With no interactive ZLE and no cache, the provider must return its frozen
+# fallback without starting a command.
+typeset -a reply
+_fsh_chroma_git_get_subcommands
+(( reply[(Ie)switch] ))
+(( ! ${_fsh_state[chroma-git-subcommands-pending]:-0} ))
+
+# A fresh runtime list replaces the fallback and refreshes an already-created
+# main chroma hash.
+_fsh_state[chroma-git-subcommands-cache]=$'   commit                  Record changes\n   nebula                  Travel through repositories'
+_fsh_state[chroma-git-subcommands-cache-ready]=1
+_fsh_state[chroma-git-subcommands-cache-born-at]=$SECONDS
+_fsh_state[chroma-git-aliases-cache]=$'alias.safe commit\nalias.shell-alias !touch /tmp/must-not-run'
+_fsh_state[chroma-git-aliases-cache-ready]=1
+_fsh_state[chroma-git-aliases-cache-born-at]=$SECONDS
+_fsh_chroma_git_get_subcommands
+[[ ${(j:,:)reply} == 'commit,nebula,safe' ]]
+(( ! reply[(Ie)shell-alias] ))
+
+# A failed or unexpectedly empty refresh preserves the last valid runtime
+# result instead of replacing it with an empty command surface.
+_fsh_state[chroma-git-subcommands-cache]='unexpected layout'
+(( ++ _fsh_state[chroma-git-subcommands-cache-born-at] ))
+_fsh_chroma_git_get_subcommands
+[[ ${(j:,:)reply} == 'commit,nebula,safe' ]]
+
+# The runtime-only option must be inserted before the frozen NO_MATCH set.
+_fsh_state[chroma-git-options-commit-cache]=$'    --future-mode       use the future mode'
+_fsh_state[chroma-git-options-commit-cache-ready]=1
+_fsh_state[chroma-git-options-commit-cache-born-at]=$SECONDS
+
+typeset -g BUFFER='git commit --future-mode' PREBUFFER=
+reply=()
+_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+[[ ${(F)reply} == $'0 3 fg=green\n4 10 fg=yellow\n11 24 fg=cyan' ]]
+[[ ${_fsh_chroma_main_git[subcmd:commit]} == \
+  *'GIT_RUNTIME_commit_R_#_opt // NO_MATCH_#_opt'* ]]
+
+BUFFER='git commit --stale-mode'
+reply=()
+_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+[[ ${(F)reply} == $'0 3 fg=green\n4 10 fg=yellow\n11 23 fg=red' ]]
+
+typeset git_source=$(<"$plugin_root/chroma/_fsh_chroma_git")
+[[ $git_source == *'_fsh_async_command chroma-git-subcommands'* ]]
+[[ $git_source == *'_fsh_async_command --capture-stderr "$key" env LC_ALL=C git "$subcommand" -h'* ]]
+
+fsh_plugin_unload

--- a/tests/integration/test-highlight-budget.zsh
+++ b/tests/integration/test-highlight-budget.zsh
@@ -1,0 +1,64 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+zmodload zsh/datetime
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-budget.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+command mkdir -p -- "$ZDOTDIR"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+zstyle ':fsh:config' bracket-highlighting disabled
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+
+integer -r buffer_length=1000
+float -r budget_seconds=0.250
+integer run
+float started elapsed median
+typeset pattern='echo a; '
+typeset BUFFER= PREBUFFER=
+typeset -a reply samples
+
+(( _fsh_max_length == buffer_length ))
+
+while (( $#BUFFER < buffer_length )); do
+  BUFFER+=$pattern
+done
+BUFFER=${BUFFER[1,buffer_length]}
+(( $#BUFFER == buffer_length ))
+
+# Warm caches before collecting five samples. The median tolerates an isolated
+# noisy runner while preserving a fixed per-keystroke regression ceiling.
+_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+(( $#reply > 0 ))
+
+for run in {1..5}; do
+  reply=()
+  started=$EPOCHREALTIME
+  _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+  elapsed=$(( EPOCHREALTIME - started ))
+  samples+=( $elapsed )
+  (( $#reply > 0 ))
+done
+
+samples=( ${(on)samples} )
+median=$samples[3]
+if (( median > budget_seconds )); then
+  builtin printf >&2 \
+    'f-sy-h: median highlight time %.3fs exceeds %.3fs at %d characters\n' \
+    $median $budget_seconds $buffer_length
+  exit 1
+fi
+
+BUFFER+=x
+region_highlight=( sentinel )
+_fsh_zle_highlight
+[[ $region_highlight == sentinel ]]
+
+fsh_plugin_unload

--- a/tests/integration/test-plugin-entrypoint.zsh
+++ b/tests/integration/test-plugin-entrypoint.zsh
@@ -13,6 +13,8 @@ typeset -gx PMSPEC=0fuUpiPs
 command mkdir -p -- "$ZDOTDIR"
 zstyle ':fsh:config' work-dir "$fixture_root/work"
 zstyle ':fsh:config' max-length 321
+zstyle ':fsh:config' chroma-cache-seconds 7
+zstyle ':fsh:config' chroma-timeout-seconds 3
 zstyle ':fsh:config' bracket-highlighting disabled
 zstyle ':fsh:config' path-blocklist '/private/*' '/mnt/slow/**'
 
@@ -31,6 +33,8 @@ source "$plugin_root/F-Sy-H.plugin.zsh"
 
 [[ $_fsh_base_dir == $plugin_root ]]
 (( _fsh_max_length == 321 ))
+(( _fsh_chroma_cache_seconds == 7 ))
+(( _fsh_chroma_timeout_seconds == 3 ))
 (( _fsh_state[use_brackets] == 0 ))
 typeset blocklist_key='/private/*'
 (( ${+_fsh_blocklist_patterns[$blocklist_key]} ))

--- a/tests/integration/test-theme-persistence.zsh
+++ b/tests/integration/test-theme-persistence.zsh
@@ -1,0 +1,78 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-themes.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset theme theme_file theme_work output
+for theme_file in "$plugin_root"/themes/*.ini(N); do
+  theme=${theme_file:t:r}
+  theme_work=$fixture_root/$theme
+  command mkdir -p -- "$theme_work/zdotdir"
+  output=$(ZDOTDIR=$theme_work/zdotdir XDG_CACHE_HOME=$theme_work/cache-home \
+    zsh -f -c '
+      zstyle ":fsh:config" work-dir "$1"
+      source "$2/F-Sy-H.plugin.zsh"
+      fsh_theme --quiet "$3"
+      [[ $_fsh_theme_name == "$3" ]]
+      [[ -s $1/current_theme.ini ]]
+      fsh_plugin_unload
+    ' zsh "$theme_work/work" "$plugin_root" "$theme" 2>&1) || {
+      builtin print -u2 -r -- "f-sy-h: shipped theme $theme failed: $output"
+      exit 1
+    }
+  [[ -z $output ]] || {
+    builtin print -u2 -r -- "f-sy-h: shipped theme $theme emitted output: $output"
+    exit 1
+  }
+done
+
+theme_work=$fixture_root/base16/work
+output=$(ZDOTDIR=$fixture_root/reload-zdotdir XDG_CACHE_HOME=$fixture_root/reload-cache \
+  zsh -f -c '
+    setopt err_exit no_unset
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    [[ $_fsh_theme_name == base16 ]]
+    (( ! ${+_fsh_styles[base16secondary]} ))
+
+    typeset -A persisted
+    integer style_count=0
+    typeset key style_key
+    _fsh_read_ini "$1/current_theme.ini" persisted
+    [[ ${persisted[<theme>_name]} == base16 ]]
+    for key in ${(k)persisted}; do
+      [[ $key == "<styles>_"* ]] || continue
+      style_key=${key#"<styles>_"}
+      [[ ${_fsh_styles[$style_key]} == ${persisted[$key]} ]]
+      (( ++style_count ))
+    done
+    (( style_count > 50 ))
+    fsh_plugin_unload
+  ' zsh "$theme_work" "$plugin_root" 2>&1) || {
+    builtin print -u2 -r -- "f-sy-h: persisted base16 theme did not reload: $output"
+    exit 1
+  }
+[[ -z $output ]] || {
+  builtin print -u2 -r -- "f-sy-h: base16 reload emitted output: $output"
+  exit 1
+}
+
+command sed \
+  's/^; secondary[[:blank:]]*=.*$/secondary = does-not-exist/' \
+  "$plugin_root/themes/base16.ini" >| "$fixture_root/invalid.ini"
+command mkdir -p -- "$fixture_root/invalid-zdotdir"
+if output=$(ZDOTDIR=$fixture_root/invalid-zdotdir XDG_CACHE_HOME=$fixture_root/invalid-cache \
+  zsh -f -c '
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    fsh_theme --quiet "$3"
+  ' zsh "$fixture_root/invalid-work" "$plugin_root" "$fixture_root/invalid.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: invalid secondary theme unexpectedly succeeded'
+  exit 1
+fi
+[[ $output == *'missing-secondary: secondary theme does not exist: does-not-exist'* ]]
+[[ ! -e $fixture_root/invalid-work/current_theme.ini ]]

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -1,0 +1,64 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-validator.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset output
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh")
+(( ${#${(f)output}} == 12 ))
+[[ $output != *'"status":"error"'* ]]
+[[ $output == *'"schema":"fsh-theme-validation/v1"'* ]]
+[[ $output == *'"declaredStyles":61,"resolvedStyles":60'* ]]
+
+command sed \
+  -e 's/^command        = 4$/command        = 999/' \
+  -e 's/^builtin        = 4$/builtin        = 0300/' \
+  "$plugin_root/themes/base16.ini" >| "$fixture_root/invalid-values.ini"
+
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/invalid-values.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: invalid theme values unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"status":"error","code":"invalid-style-value"'* ]]
+[[ $output == *'command has invalid color or style element: 999'* ]]
+[[ $output == *'builtin has invalid color or style element: 0300'* ]]
+
+{
+  builtin print -r -- '[base]'
+  builtin print -r -- 'default=none'
+  builtin print -r -- 'default=green'
+} >| "$fixture_root/duplicate.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/duplicate.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: duplicate theme key unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"status":"error","code":"duplicate-key"'* ]]
+
+{
+  builtin print -r -- '[base]'
+  builtin print -r -- 'comment=123'
+} >| "$fixture_root/sample-overlay.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/sample-overlay.ini")
+[[ $output == *'"status":"ok"'*'"declaredStyles":1,"resolvedStyles":0'* ]]
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+command mkdir -p -- "$ZDOTDIR"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+source "$plugin_root/F-Sy-H.plugin.zsh"
+fsh_theme --quiet "$fixture_root/sample-overlay.ini"
+[[ -s $fixture_root/work/theme_overlay.ini ]]
+if fsh_theme --quiet "$fixture_root/invalid-values.ini" 2>"$fixture_root/theme-error"; then
+  builtin print -u2 -r -- 'f-sy-h: invalid theme unexpectedly loaded'
+  exit 1
+fi
+[[ $(<"$fixture_root/theme-error") == *'invalid-style-value'* ]]
+[[ ! -e $fixture_root/work/current_theme.ini ]]
+fsh_plugin_unload

--- a/tests/unit/main.zunit
+++ b/tests/unit/main.zunit
@@ -169,3 +169,45 @@ reply=()
     assert "$output" is_empty
     assert "$state" same_as "0"
 }
+
+@test 'default highlighting stays within the performance budget' {
+    run zsh -f ./tests/integration/test-highlight-budget.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}
+
+@test 'shipped themes persist and reject invalid secondary themes' {
+    run zsh -f ./tests/integration/test-theme-persistence.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}
+
+@test 'chroma registry is unique, reachable, and explicitly extensible' {
+    run zsh -f ./tests/integration/test-chroma-registry.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}
+
+@test 'git, zi, docker, and generic chromas emit exact regions' {
+    run zsh -f ./tests/integration/test-chroma-regions.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}
+
+@test 'docker chroma never forks synchronously' {
+    run zsh -f ./tests/integration/test-async-chroma.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}
+
+@test 'theme schema rejects malformed and out-of-range declarations' {
+    run zsh -f ./tests/integration/test-theme-validator.zsh
+
+    assert "$output" is_empty
+    assert "$state" same_as "0"
+}

--- a/themes/base16.ini
+++ b/themes/base16.ini
@@ -13,7 +13,7 @@ incorrect-subtle = 1
 subtle-separator = 12
 subtle-bg        = bg:10
 ; secondary        =
-; recursive-base   =
+recursive-base     = none
 
 [command-point]
 reserved-word  = 5
@@ -49,6 +49,7 @@ double-hyphen-option   = 3
 back-quoted-argument   = none
 single-quoted-argument = 2
 double-quoted-argument = 2
+optarg-string          = 2
 dollar-quoted-argument = 2
 
 [in-string]
@@ -66,6 +67,7 @@ history-expansion    = 6,bold
 [math]
 mathvar = 1
 mathnum = 9
+optarg-number = 9
 matherr = 1,bold
 
 [for-loop]

--- a/themes/clean.ini
+++ b/themes/clean.ini
@@ -10,6 +10,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:17
 secondary        = zdharma
 recursive-base   = 183
@@ -48,6 +49,7 @@ double-hyphen-option   = 185
 back-quoted-argument   = none
 single-quoted-argument = 147
 double-quoted-argument = 147
+optarg-string          = 147
 dollar-quoted-argument = 147
 
 [in-string]
@@ -65,6 +67,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = 208
+optarg-number = 208
 matherr = 124
 
 [for-loop]

--- a/themes/default.ini
+++ b/themes/default.ini
@@ -15,7 +15,7 @@ incorrect-subtle = red
 subtle-separator = green
 subtle-bg        = bg:18
 secondary        = free
-; recursive-base   =
+recursive-base     = none
 
 [command-point]
 reserved-word  = yellow
@@ -51,6 +51,7 @@ double-hyphen-option   = cyan
 back-quoted-argument   = none
 single-quoted-argument = yellow
 double-quoted-argument = yellow
+optarg-string          = yellow
 dollar-quoted-argument = yellow
 
 [in-string]
@@ -68,6 +69,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = magenta
+optarg-number = magenta
 matherr = red
 
 [for-loop]

--- a/themes/forest.ini
+++ b/themes/forest.ini
@@ -10,6 +10,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:18
 secondary        = zdharma
 recursive-base   = 183
@@ -48,6 +49,7 @@ double-hyphen-option   = 65
 back-quoted-argument   = none
 single-quoted-argument = 186
 double-quoted-argument = 186
+optarg-string          = 186
 dollar-quoted-argument = 186
 
 [in-string]
@@ -65,6 +67,7 @@ history-expansion    = 114
 [math]
 mathvar = 114
 mathnum = 107
+optarg-number = 107
 matherr = 124
 
 [for-loop]

--- a/themes/free.ini
+++ b/themes/free.ini
@@ -10,6 +10,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:18
 secondary        = zdharma
 recursive-base   = 183
@@ -48,6 +49,7 @@ double-hyphen-option   = 110
 back-quoted-argument   = none
 single-quoted-argument = 150
 double-quoted-argument = 150
+optarg-string          = 150
 dollar-quoted-argument = 150
 
 [in-string]
@@ -65,6 +67,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = 166
+optarg-number = 166
 matherr = red
 
 [for-loop]

--- a/themes/q-jmnemonic.ini
+++ b/themes/q-jmnemonic.ini
@@ -50,6 +50,7 @@ recursive-base    = 183
 [background]
 correct-subtle   = bg:18
 incorrect-subtle = bg:238
+subtle-separator = 104
 subtle-bg        = bg:17
 global-alias     = bg:20
 
@@ -79,6 +80,7 @@ variable             = none
 [magenta-3]
 dollar-quoted-argument = 173
 double-quoted-argument = 173
+optarg-string          = 173
 history-expansion      = 173
 globbing-ext           = 173
 precommand             = 173
@@ -147,6 +149,7 @@ bracket-level-3 = 220
 [math]
 mathvar = 68
 mathnum = 173
+optarg-number = 173
 matherr = 124
 
 [for-loop]

--- a/themes/safari.ini
+++ b/themes/safari.ini
@@ -12,6 +12,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:18
 secondary        = zdharma
 recursive-base   = 183
@@ -50,6 +51,7 @@ double-hyphen-option   = 152
 back-quoted-argument   = none
 single-quoted-argument = 151
 double-quoted-argument = 151
+optarg-string          = 151
 dollar-quoted-argument = 151
 
 [in-string]
@@ -67,6 +69,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = 187
+optarg-number = 187
 matherr = red
 
 [for-loop]

--- a/themes/spa.ini
+++ b/themes/spa.ini
@@ -11,6 +11,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = 150
 subtle-bg        = bg:17
 secondary        = zdharma
 recursive-base   = 183
@@ -49,6 +50,7 @@ double-hyphen-option   = 185
 back-quoted-argument   = none
 single-quoted-argument = 110
 double-quoted-argument = 110
+optarg-string          = 110
 dollar-quoted-argument = 110
 
 [in-string]
@@ -66,6 +68,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = 150
 mathnum = 110
+optarg-number = 110
 matherr = 196
 
 [for-loop]

--- a/themes/sv-orple.ini
+++ b/themes/sv-orple.ini
@@ -29,6 +29,7 @@ exec-descriptor  = 140
 comment          = 61
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = 146
 subtle-bg        = bg:17
 secondary        = clean
 recursive-base   = 186
@@ -67,6 +68,7 @@ double-hyphen-option   = 140
 back-quoted-argument   = none
 single-quoted-argument = 173
 double-quoted-argument = 173
+optarg-string          = 173
 dollar-quoted-argument = 173
 
 [in-string]
@@ -84,6 +86,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = 140
 mathnum = 173
+optarg-number = 173
 matherr = 124
 
 [for-loop]

--- a/themes/sv-plant.ini
+++ b/themes/sv-plant.ini
@@ -29,6 +29,7 @@ exec-descriptor  = 180
 comment          = 58
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = 189
 subtle-bg        = bg:17
 secondary        = zdharma
 recursive-base   = 183
@@ -67,6 +68,7 @@ double-hyphen-option   = 180
 back-quoted-argument   = none
 single-quoted-argument = 114
 double-quoted-argument = 114
+optarg-string          = 114
 dollar-quoted-argument = 114
 
 [in-string]
@@ -84,6 +86,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = 180
 mathnum = 114
+optarg-number = 114
 matherr = 124
 
 [for-loop]

--- a/themes/z-shell.ini
+++ b/themes/z-shell.ini
@@ -10,6 +10,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:17
 secondary        = base16
 recursive-base   = 190
@@ -48,6 +49,7 @@ double-hyphen-option   = 45
 back-quoted-argument   = none
 single-quoted-argument = 48
 double-quoted-argument = 48
+optarg-string          = 48
 dollar-quoted-argument = 48
 
 [in-string]
@@ -65,6 +67,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = 82
+optarg-number = 82
 matherr = red
 
 [for-loop]

--- a/themes/zdharma.ini
+++ b/themes/zdharma.ini
@@ -10,6 +10,7 @@ exec-descriptor  = yellow,bold
 comment          = 243
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
+subtle-separator = none
 subtle-bg        = bg:17
 secondary        = safari
 recursive-base   = 186
@@ -48,6 +49,7 @@ double-hyphen-option   = 177
 back-quoted-argument   = none
 single-quoted-argument = 146
 double-quoted-argument = 146
+optarg-string          = 146
 dollar-quoted-argument = 146
 
 [in-string]
@@ -65,6 +67,7 @@ history-expansion    = blue,bold
 [math]
 mathvar = blue,bold
 mathnum = 154
+optarg-number = 154
 matherr = red
 
 [for-loop]

--- a/tools/validate-themes.zsh
+++ b/tools/validate-themes.zsh
@@ -1,0 +1,51 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h}
+fpath=( "$plugin_root/functions" $fpath )
+source "$plugin_root/lib/theme-schema.zsh"
+autoload -Uz _fsh_read_ini _fsh_validate_theme
+
+json_escape() {
+  emulate -L zsh
+
+  REPLY=${1//\\/\\\\}
+  REPLY=${REPLY//\"/\\\"}
+  REPLY=${REPLY//$'\n'/\\n}
+  REPLY=${REPLY//$'\r'/\\r}
+  REPLY=${REPLY//$'\t'/\\t}
+}
+
+typeset -a theme_paths=( "$@" )
+(( $#theme_paths )) || theme_paths=( "$plugin_root"/themes/*.ini(N) )
+
+typeset theme_path path_json diagnostic code message code_json message_json
+integer exit_status=0
+for theme_path in "${theme_paths[@]}"; do
+  json_escape "${theme_path:A}"
+  path_json=$REPLY
+  if _fsh_validate_theme "$theme_path" "$plugin_root/themes"; then
+    builtin printf \
+      '{"schema":"fsh-theme-validation/v1","path":"%s","status":"ok","code":"ok","message":"","declaredStyles":%d,"resolvedStyles":%d}\n' \
+      "$path_json" $_fsh_theme_declared_count $_fsh_theme_resolved_count
+    continue
+  fi
+
+  exit_status=1
+  for diagnostic in "${_fsh_theme_validation_errors[@]}"; do
+    code=${diagnostic%%|*}
+    message=${diagnostic#*|}
+    json_escape "$code"
+    code_json=$REPLY
+    json_escape "$message"
+    message_json=$REPLY
+    builtin printf \
+      '{"schema":"fsh-theme-validation/v1","path":"%s","status":"error","code":"%s","message":"%s","declaredStyles":%d,"resolvedStyles":%d}\n' \
+      "$path_json" "$code_json" "$message_json" \
+      $_fsh_theme_declared_count $_fsh_theme_resolved_count
+  done
+done
+
+exit exit_status


### PR DESCRIPTION
## Summary

- add a strict canonical theme schema, validator, safe persistence, and CI coverage
- make chroma registration deterministic and add exact-region fixture profiles
- move Docker and Git discovery off the ZLE hot path with asynchronous cached workers
- derive Git commands and options from safe built-in runtime help with frozen fallbacks
- lower the default highlight cap and enforce a measured 250 ms integration budget

## Architecture

The runtime chroma provider implements the decision proposed in [z-shell/.github#571](https://github.com/z-shell/.github/pull/571). Git discovery excludes shell aliases and external `git-*` commands from per-command probing, admits only constrained tokens, and preserves the last valid result on failed refresh.

## Issues

Addresses #64, #65, #66, #68, #73, #80, #82, #90, and #93.

## Validation

- Zsh 5.9.2 syntax and `zcompile` checks for 62 native files
- 14 integration profiles, including the real interactive `zle -F` callback
- 12 theme records validated against `fsh-theme-validation/v1`
- actionlint 1.7.12
- tracked diff and changed-file text checks

ZUnit was unavailable locally. The workflow runs the integration matrix on Zsh 5.8 and the pinned Zsh 5.9.2 build.
