### PR TITLE
fix(plugin): guide zsh-syntax-highlighting migration

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -51,6 +51,11 @@ if (( $#lifecycle_collisions )); then
   return 2
 fi
 
+if (( ${+ZSH_HIGHLIGHT_STYLES} || ${+ZSH_HIGHLIGHT_HIGHLIGHTERS} )); then
+  builtin print -u2 -r -- \
+    'f-sy-h: detected unsupported zsh-syntax-highlighting configuration; see README.md: Migrating from zsh-syntax-highlighting'
+fi
+
 builtin source -- "$plugin_dir/lib/lifecycle.zsh" || return
 _fsh_lifecycle_begin "${lifecycle_modules[@]}" || return
 builtin source -- "$plugin_dir/lib/theme-schema.zsh" || {

--- a/README.md
+++ b/README.md
@@ -123,6 +123,68 @@ clean interface. Existing configurations need these changes:
 Legacy functions, aliases, parameters, and executable cache formats are not
 retained as a second compatibility interface.
 
+### Migrating from zsh-syntax-highlighting
+
+F-Sy-H is not configuration-compatible with zsh-syntax-highlighting. Remove
+`ZSH_HIGHLIGHT_STYLES` and `ZSH_HIGHLIGHT_HIGHLIGHTERS` configuration when
+switching plugins. F-Sy-H does not read or translate either parameter. If one
+is already declared when F-Sy-H loads, the plugin prints one migration
+diagnostic without reading or changing its values.
+
+[Zsh requires associative arrays to be declared before assigning an
+element](https://zsh.sourceforge.io/Doc/Release/Parameters.html#Array-Parameters).
+For example, [zsh-syntax-highlighting documents this
+sequence](https://github.com/zsh-users/zsh-syntax-highlighting/blob/master/docs/highlighters/main.md#how-to-tweak-it):
+
+```zsh
+typeset -A ZSH_HIGHLIGHT_STYLES
+ZSH_HIGHLIGHT_STYLES[comment]='fg=201'
+```
+
+Without the `typeset -A` line, Zsh reports `assignment to invalid subscript
+range` at the assignment itself. If that assignment appears before the F-Sy-H
+source or manager command, F-Sy-H has not run yet and cannot intercept the
+error. Remove the legacy block instead of moving it after the F-Sy-H load.
+
+Replace the legacy controls as follows:
+
+| zsh-syntax-highlighting                              | F-Sy-H replacement                                                               |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `ZSH_HIGHLIGHT_MAXLENGTH=1000`                       | `zstyle ':fsh:config' max-length 1000`                                           |
+| `ZSH_HIGHLIGHT_HIGHLIGHTERS=(main)`                  | Main syntax highlighting is integrated and always active.                        |
+| Add `brackets` to `ZSH_HIGHLIGHT_HIGHLIGHTERS`       | `zstyle ':fsh:config' bracket-highlighting enabled`                              |
+| Add `pattern`, `regexp`, `cursor`, `root`, or `line` | No direct equivalent. Remove the entry or implement the behavior outside F-Sy-H. |
+| `ZSH_HIGHLIGHT_STYLES[...]`                          | Copy and edit an F-Sy-H INI theme, then apply it with `fsh_theme`.               |
+
+Many common `main` highlighter style names map directly to F-Sy-H theme keys:
+
+| zsh-syntax-highlighting style                                              | F-Sy-H theme key |
+| -------------------------------------------------------------------------- | ---------------- |
+| `unknown-token`, `reserved-word`, `alias`, `suffix-alias`, `global-alias`  | Same name        |
+| `builtin`, `function`, `command`, `precommand`, `hashed-command`           | Same name        |
+| `commandseparator`, `path`, `path_pathseparator`, `globbing`               | Same name        |
+| `history-expansion`, `single-hyphen-option`, `double-hyphen-option`        | Same name        |
+| `back-quoted-argument`, `single-quoted-argument`, `double-quoted-argument` | Same name        |
+| `dollar-quoted-argument`, `assign`, `redirection`, `comment`, `default`    | Same name        |
+
+Other zsh-syntax-highlighting keys do not have a one-to-one mapping. F-Sy-H
+uses more specific keys for arithmetic, loops, case blocks, here strings,
+bracket levels, directories, subcommands, and command option arguments. Start
+from a shipped theme so those F-Sy-H-specific styles retain valid fallbacks:
+
+```zsh
+theme_dir=${XDG_CONFIG_HOME:-$HOME/.config}/f-sy-h
+mkdir -p -- "$theme_dir"
+fsh_theme --copy-shipped-theme default "$theme_dir/migrated"
+# Edit "$theme_dir/migrated.ini", then apply it:
+fsh_theme "$theme_dir/migrated.ini"
+```
+
+Theme INI values use `red,bold` for a foreground and `bg:blue` for a
+background. The corresponding zsh-syntax-highlighting forms are `fg=red,bold`
+and `bg=blue`. Run `fsh_theme --help` for theme commands and see the
+configuration section below for the full `:fsh:config` interface.
+
 ## Configuration
 
 All ordinary settings use `:fsh:config`. Set them before loading the plugin:

--- a/tests/integration/test-plugin-entrypoint.zsh
+++ b/tests/integration/test-plugin-entrypoint.zsh
@@ -7,10 +7,11 @@ typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
 typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-entrypoint.XXXXXXXX")
 trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
 
+typeset -gx HOME=$fixture_root/home
 typeset -gx ZDOTDIR=$fixture_root/zdotdir
 typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
 typeset -gx PMSPEC=0fuUpiPs
-command mkdir -p -- "$ZDOTDIR"
+command mkdir -p -- "$HOME" "$ZDOTDIR"
 zstyle ':fsh:config' work-dir "$fixture_root/work"
 zstyle ':fsh:config' max-length 321
 zstyle ':fsh:config' chroma-cache-seconds 7
@@ -28,6 +29,50 @@ count_fpath_entry() {
   done
   REPLY=$count
 }
+
+typeset -r migration_warning='f-sy-h: detected unsupported zsh-syntax-highlighting configuration; see README.md: Migrating from zsh-syntax-highlighting'
+typeset legacy_case legacy_output
+for legacy_case in styles highlighters both; do
+  legacy_output=$(
+    command zsh -f -c '
+      builtin emulate -R zsh
+      builtin setopt err_exit no_unset
+
+      case $2 in
+        (styles)
+          typeset -A ZSH_HIGHLIGHT_STYLES=( comment "fg=201" )
+          ;;
+        (highlighters)
+          typeset -a ZSH_HIGHLIGHT_HIGHLIGHTERS=( main brackets )
+          ;;
+        (both)
+          typeset -A ZSH_HIGHLIGHT_STYLES=( comment "fg=201" )
+          typeset -a ZSH_HIGHLIGHT_HIGHLIGHTERS=( main brackets )
+          ;;
+      esac
+
+      builtin source "$1"
+      builtin source "$1"
+
+      if [[ $2 == styles || $2 == both ]]; then
+        [[ ${ZSH_HIGHLIGHT_STYLES[comment]} == "fg=201" ]]
+      fi
+      if [[ $2 == highlighters || $2 == both ]]; then
+        [[ ${(j: :)ZSH_HIGHLIGHT_HIGHLIGHTERS} == "main brackets" ]]
+      fi
+
+      fsh_plugin_unload
+
+      if [[ $2 == styles || $2 == both ]]; then
+        [[ ${ZSH_HIGHLIGHT_STYLES[comment]} == "fg=201" ]]
+      fi
+      if [[ $2 == highlighters || $2 == both ]]; then
+        [[ ${(j: :)ZSH_HIGHLIGHT_HIGHLIGHTERS} == "main brackets" ]]
+      fi
+    ' zsh "$plugin_root/F-Sy-H.plugin.zsh" "$legacy_case" 2>&1
+  )
+  [[ $legacy_output == "$migration_warning" ]]
+done
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
 


### PR DESCRIPTION
# Pull request

## Summary

- Detect already-declared zsh-syntax-highlighting configuration and emit one value-free migration diagnostic.
- Preserve legacy parameter values across load, repeated sourcing, and unload.
- Document the explicit incompatibility, declaration-order limitation, highlighter replacements, common style mappings, and theme migration workflow.

Closes #95

## Verification

- Native `zsh -f -n` and `zcompile -U -z`: passed for 63 production, integration, and tool sources.
- Repository integration profiles: 14 passed, including interactive and non-interactive lifecycle coverage.
- `zsh -f tools/validate-themes.zsh`: passed for all shipped themes.
- ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 21 passed, 0 failed, 0 errors, 0 warnings.
- `trunk check --no-progress`: no issues in the three modified files.
- `git diff --check`: passed.

## Compatibility and lifecycle

Clean loads remain silent. If either unsupported legacy parameter already exists, F-Sy-H prints one diagnostic without reading or changing its value. Repeated sourcing does not repeat the message, and unload leaves the legacy parameters unchanged. No plugin-manager-specific compatibility path is added.

## Agent handoff

No handoff needed.
