### PR TITLE
chore(deps): enable Renovate routine updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>z-shell/.github:renovate-config",
+    ":dependencyDashboardApproval",
+    ":disableVulnerabilityAlerts"
+  ]
+}


### PR DESCRIPTION
# Pull request

## Summary

- Add the repository Renovate consumer configuration extending the organization preset.
- Require Dependency Dashboard approval and leave vulnerability-alert ownership with Dependabot.
- Retain the existing routine Dependabot configuration until Renovate processing is proven after merge.

Refs #97

## Verification

- Renovate `44.51.2` config validator: passed; the optional native RE2 module was unavailable and Renovate used its RegExp fallback.
- `jq` structure assertions: passed.
- Trunk checks excluding the incomplete cached gitleaks launcher: passed.
- Gitleaks `8.30.1` direct scan: no leaks.
- `git diff --check`: passed.

## Compatibility and lifecycle

No plugin runtime or lifecycle impact. This changes dependency automation only.

## Agent handoff

**Status:** Ready for review
**Repository:** z-shell/F-Sy-H
**Branch/PR:** `bug-97`
**Tracker/Issue:** #97

### Current state

- The Renovate App is installed for all organization repositories and is not suspended.
- Dependency graph, Dependabot alerts, and Dependabot security updates are enabled.
- Renovate is currently disabled for F-Sy-H because onboarding PR #16 was closed unmerged with no repository config.

### Blockers

- None for this phase.

### Next steps

1. Merge this configuration after review.
2. Confirm Renovate processes F-Sy-H and creates or updates its Dependency Dashboard.
3. Remove `.github/dependabot.yml` so routine updates have one owner.
4. Resolve the superseded routine Dependabot PR #106 and close #97 only after the migration is verified.
