### PR TITLE
perf: add conservative incremental highlighting

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -65,6 +65,7 @@ jobs:
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
           zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-incremental-highlighting.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
           zsh -f tests/integration/test-chroma-regions.zsh
@@ -130,6 +131,7 @@ jobs:
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
           zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-incremental-highlighting.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
           zsh -f tests/integration/test-chroma-regions.zsh

--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -128,6 +128,7 @@ _fsh_zle_highlight() {
   # Remove all highlighting in isearch, so that only the underlining done by zsh itself remains.
   # For details see FAQ entry 'Why does syntax highlighting not work while searching history?'.
   if [[ $WIDGET == zle-isearch-update ]] && ! (( $+ISEARCHMATCH_ACTIVE )); then
+    _fsh_incremental_reset
     region_highlight=()
     return $ret
   fi
@@ -137,16 +138,21 @@ _fsh_zle_highlight() {
 
   # Skip highlighting above the configured buffer-length limit. Long buffers
   # are commonly pasted commands or generated lists.
-  [[ -n ${_fsh_max_length:-} ]] && [[ $#BUFFER -gt $_fsh_max_length ]] && return $ret
+  if [[ -n ${_fsh_max_length:-} ]] && [[ $#BUFFER -gt $_fsh_max_length ]]; then
+    _fsh_incremental_reset
+    return $ret
+  fi
 
   # Do not highlight if there are pending inputs (copy/paste).
-  [[ $PENDING -gt 0 ]] && return $ret
+  if [[ $PENDING -gt 0 ]]; then
+    _fsh_incremental_reset
+    return $ret
+  fi
 
   # Reset region highlight to build it from scratch
   # may need to remove path_prefix highlighting when the line ends
   if [[ $WIDGET == zle-line-finish ]] || _fsh_buffer_modified; then
-    _fsh_highlight_init
-    _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
+    _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
     (( _fsh_state[use_brackets] )) && {
       _fsh_main_cache=( $reply )
       _fsh_highlight_string_process "$PREBUFFER" "$BUFFER"
@@ -366,6 +372,7 @@ _fsh_preexec_hook() {
   typeset -gi _fsh_prior_cursor=0
   typeset -ga _fsh_main_cache
   _fsh_main_cache=()
+  _fsh_incremental_reset
 }
 
 if [[ -o interactive ]]; then

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ The settings are:
 For boolean-like settings, `disabled`, `false`, `no`, `off`, and `0` disable
 the feature; any other value enables it.
 
+At or below `max-length`, edits to independent simple command lists can reuse
+highlighting before a parser-confirmed top-level semicolon or newline. Quoting,
+redirections, assignments, aliases, chroma, control structures, changed theme
+or shell context, and other ambiguous input use a full parse. Bracket and
+string highlighting still scan the complete buffer. Buffers above the limit
+remain unhighlighted rather than switching to a degraded highlighting mode.
+
 Theme file examples and additional usage guidance are documented in the
 [wiki guide](https://wiki.zshell.dev/ecosystem/plugins/f-sy-h).
 
@@ -284,6 +291,7 @@ zsh -f tests/integration/test-git-chroma-regions.zsh
 zsh -f tests/integration/test-passive-safety.zsh
 zsh -f tests/integration/test-hostile-autoloads.zsh
 zsh -f tests/integration/test-highlight-budget.zsh
+zsh -f tests/integration/test-incremental-highlighting.zsh
 zsh -f tests/integration/test-theme-persistence.zsh
 zsh -f tests/integration/test-chroma-registry.zsh
 zsh -f tests/integration/test-chroma-regions.zsh
@@ -293,9 +301,12 @@ zsh -f tools/validate-themes.zsh
 zunit
 ```
 
-The highlight-budget profile measures five parses of a fixed 1,000-character
-buffer after one warm-up run. Its median must remain at or below 250 ms, and a
-buffer above the default limit must take the skip path.
+The highlight-budget profile compares five full parses and five eligible end
+edits at 100, 500, and 1,000 characters. At 1,000 characters, both medians must
+remain at or below 250 ms and the incremental median must be at least 30 percent
+faster. A buffer above the default limit must take the skip path. The
+incremental-highlighting profile compares ordered regions with full parses for
+targeted invalidation cases and 100 seeded edits.
 
 `tools/validate-themes.zsh` validates all shipped themes by default and accepts
 explicit INI paths as arguments. It emits one JSON Lines record per result or

--- a/functions/_fsh_async_command_callback
+++ b/functions/_fsh_async_command_callback
@@ -29,6 +29,7 @@ builtin unset \
   "_fsh_state[_fsh-async-fd-$fd-key]"
 
 typeset -g _fsh_prior_buffer=
+_fsh_incremental_reset
 builtin true
 _fsh_zle_highlight
 zle -R

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -322,6 +322,26 @@ typeset -gA _fsh_assigns_seen
 # for other scripts to process
 typeset -ga _fsh_last_commands
 
+# Conservative incremental-highlighting state. Checkpoints are emitted by the
+# main parser only for complete simple-command prefixes. Anything outside that
+# narrow grammar makes the full parser the sole source of highlighting output.
+typeset -gi _fsh_incremental_cache_valid=0
+typeset -gi _fsh_incremental_collect=0
+typeset -gi _fsh_incremental_last_used=0
+typeset -gi _fsh_incremental_parse_safe=0
+typeset -g _fsh_incremental_buffer=
+typeset -g _fsh_incremental_fingerprint=
+typeset -g _fsh_incremental_prebuffer=
+typeset -ga _fsh_incremental_checkpoints
+typeset -ga _fsh_incremental_checkpoint_command_counts
+typeset -ga _fsh_incremental_checkpoint_region_counts
+typeset -gA _fsh_incremental_command_types
+typeset -ga _fsh_incremental_commands
+typeset -ga _fsh_incremental_parse_checkpoints
+typeset -ga _fsh_incremental_parse_command_counts
+typeset -ga _fsh_incremental_parse_region_counts
+typeset -ga _fsh_incremental_regions
+
 # Get the type of a command.
 #
 # Uses the zsh/parameter module if available to avoid forks, and a
@@ -422,7 +442,7 @@ _fsh_highlight_process() {
   # __arg_type can be 0, 1, 2 or 3, i.e. precommand, control flow, command separator
   # __idx and _end_idx are used in sub-functions
   # for this_word and next_word look below at commented integers and at state machine description
-  integer __arg_type=0 MBEGIN MEND in_redirection __len=${#__buf} __PBUFLEN=${#1} already_added offset __idx _end_idx this_word=1 next_word=0 __pos  __asize __delimited=0 itmp iitmp
+  integer __arg_type=0 MBEGIN MEND in_redirection __len=${#__buf} __PBUFLEN=${#1} already_added offset __idx _end_idx this_word=1 next_word=0 __pos  __asize __delimited=0 itmp iitmp incremental_collect=$_fsh_incremental_collect
   integer chroma_global_alias chroma_reply_count chroma_start_pos chroma_already_added chroma_status
   local -a match mbegin mend __inputs __list
 
@@ -487,6 +507,7 @@ _fsh_highlight_process() {
   _fsh_state[chroma-zi-ice-elements-id-as]=""
 
   [[ -n $ZCALC_ACTIVE ]] && {
+    (( incremental_collect )) && _fsh_incremental_parse_safe=0
     _start_pos=0; _end_pos=__len; __arg=$__buf
     _fsh_highlight_math_string
     return 0
@@ -537,6 +558,12 @@ _fsh_highlight_process() {
 
       proc_buf=${proc_buf[offset + __asize + 1,__len]}
       _start_pos=$_end_pos
+      if (( incremental_collect && _fsh_incremental_parse_safe &&
+        ! in_array_assignment && this_word == 1 )) && [[ -z $braces_stack ]]; then
+        _fsh_incremental_parse_checkpoints+=( $(( _end_pos - __PBUFLEN )) )
+        _fsh_incremental_parse_region_counts+=( $#reply )
+        _fsh_incremental_parse_command_counts+=( $#_fsh_last_commands )
+      fi
       continue
     else
       offset=0
@@ -607,6 +634,7 @@ _fsh_highlight_process() {
    fi
 
    if (( this_word & 8192 )); then
+     (( incremental_collect )) && _fsh_incremental_parse_safe=0
      __list=( ${(z@)${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#} )
      (( chroma_global_alias = ${+galiases[(e)${(Q)__arg}]} ))
      if (( chroma_global_alias )); then
@@ -630,6 +658,7 @@ _fsh_highlight_process() {
      _mybuf=${${aliases[$active_command]:-${active_command##*/}}##[[:space:]]#(command|builtin|exec|noglob|nocorrect|pkexec)[[:space:]]#}
      [[ "$_mybuf" = (#b)(FPATH+(#c0,1)=)* ]] && _mybuf="${match[1]} ${(j: :)${(s,:,)${_mybuf#FPATH+(#c0,1)=}}}"
      [[ -n ${_fsh_state[chroma-${_mybuf%% *}]} ]] && {
+       (( incremental_collect )) && _fsh_incremental_parse_safe=0
        __list=( ${(z@)_mybuf} )
        if (( ${#__list} > 1 )) || [[ $active_command != $_mybuf ]]; then
          __style=${_fsh_theme_name}alias
@@ -664,9 +693,11 @@ _fsh_highlight_process() {
     (( next_word = 1 | (this_word & BIT_case_code) ))
   elif (( (this_word & 1) && (in_redirection == 0) )) || [[ $braces_stack = T* ]]; then # T - typedef, etc.
     if (( __arg_type == 1 )); then
+      (( incremental_collect )) && _fsh_incremental_parse_safe=0
       __style=${_fsh_theme_name}precommand
       [[ $__arg = "command" || $__arg = "exec" ]] && (( next_word = next_word | 64 ))
     elif [[ $__arg = (sudo|doas) ]]; then
+      (( incremental_collect )) && _fsh_incremental_parse_safe=0
       __style=${_fsh_theme_name}precommand
       (( next_word = (next_word & ~2) | 4 | 1 ))
     else
@@ -686,6 +717,7 @@ _fsh_highlight_process() {
 
       case $REPLY in
         reserved)       # reserved word
+          (( incremental_collect )) && _fsh_incremental_parse_safe=0
           [[ $__arg = "[[" ]] && __style=${_fsh_theme_name}double-sq-bracket || __style=${_fsh_theme_name}reserved-word
           if [[ $__arg == $'\x7b' ]]; then # Y - '{'
             braces_stack='Y'$braces_stack
@@ -711,9 +743,16 @@ _fsh_highlight_process() {
             braces_stack='T'$braces_stack
           fi
         ;;
-        'suffix alias') __style=${_fsh_theme_name}suffix-alias;;
-        'global alias') __style=${_fsh_theme_name}global-alias;;
+        'suffix alias')
+          (( incremental_collect )) && _fsh_incremental_parse_safe=0
+          __style=${_fsh_theme_name}suffix-alias
+          ;;
+        'global alias')
+          (( incremental_collect )) && _fsh_incremental_parse_safe=0
+          __style=${_fsh_theme_name}global-alias
+          ;;
         alias)
+          (( incremental_collect )) && _fsh_incremental_parse_safe=0
           if [[ $__arg = ?*'='* ]]; then
             # The so called (by old code) "insane_alias"
             __style=${_fsh_theme_name}unknown-token
@@ -1110,6 +1149,7 @@ _fsh_highlight_process() {
                  elif (( in_redirection == 2 )); then
                    __style=${_fsh_theme_name}redirection
                  elif (( ${+galiases[(e)${(Q)__arg}]} )); then
+                   (( incremental_collect )) && _fsh_incremental_parse_safe=0
                    __style=${_fsh_theme_name}global-alias
                  else
                    if [[ ${_fsh_state[no_check_paths]} != 1 ]]; then
@@ -1509,6 +1549,191 @@ _fsh_highlight_dollar_string() {
 _fsh_highlight_init() {
   _fsh_complex_brackets=()
   _fsh_command_type_cache=()
+}
+
+_fsh_incremental_reset() {
+  builtin emulate -L zsh
+
+  _fsh_incremental_cache_valid=0
+  _fsh_incremental_buffer=
+  _fsh_incremental_fingerprint=
+  _fsh_incremental_prebuffer=
+  _fsh_incremental_checkpoints=()
+  _fsh_incremental_checkpoint_command_counts=()
+  _fsh_incremental_checkpoint_region_counts=()
+  _fsh_incremental_command_types=()
+  _fsh_incremental_commands=()
+  _fsh_incremental_regions=()
+}
+
+_fsh_incremental_make_fingerprint() {
+  builtin emulate -L zsh
+
+  local fingerprint=$_fsh_theme_name
+  fingerprint+=$'\x1f'${(qqq)${(kv)_fsh_styles}}
+  fingerprint+=$'\x1c'${(qqq)${(kv)galiases}}
+  fingerprint+=$'\x1d'$PWD$'\x1d'$PATH$'\x1d'${CDPATH-}
+  fingerprint+=$'\x1d'${_fsh_state[no_check_paths]-}$'\x1d'${_fsh_state[use_async]-}
+  fingerprint+=$'\x1d'${_fsh_state[use_brackets]-}$'\x1d'${LASTWIDGET-}
+  REPLY=$fingerprint
+}
+
+_fsh_incremental_capture_command_types() {
+  builtin emulate -L zsh
+
+  local command
+  _fsh_incremental_command_types=()
+  for command in "${_fsh_incremental_commands[@]}"; do
+    (( ${+_fsh_incremental_command_types[(e)$command]} )) && continue
+    _fsh_highlight_main_type "$command"
+    _fsh_incremental_command_types[(e)$command]=$REPLY
+  done
+}
+
+_fsh_incremental_store_full() {
+  builtin emulate -L zsh
+
+  local prebuffer=$1 buffer=$2
+
+  if [[ -n $prebuffer ]] || (( ! _fsh_incremental_parse_safe )) ||
+    (( ! $#_fsh_incremental_parse_checkpoints )); then
+    _fsh_incremental_reset
+    return 0
+  fi
+
+  _fsh_incremental_make_fingerprint
+  _fsh_incremental_fingerprint=$REPLY
+  _fsh_incremental_prebuffer=$prebuffer
+  _fsh_incremental_buffer=$buffer
+  _fsh_incremental_regions=( "${reply[@]}" )
+  _fsh_incremental_commands=( "${_fsh_last_commands[@]}" )
+  _fsh_incremental_checkpoints=( "${_fsh_incremental_parse_checkpoints[@]}" )
+  _fsh_incremental_checkpoint_region_counts=( "${_fsh_incremental_parse_region_counts[@]}" )
+  _fsh_incremental_checkpoint_command_counts=( "${_fsh_incremental_parse_command_counts[@]}" )
+  _fsh_incremental_capture_command_types
+  _fsh_incremental_cache_valid=1
+}
+
+_fsh_incremental_try() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob typeset_silent
+
+  local prebuffer=$1 buffer=$2 suffix command
+  local -a prefix_regions prefix_commands suffix_regions suffix_commands
+  local -a retained_checkpoints retained_region_counts retained_command_counts
+  local -A checked_commands
+  integer common=0 common_limit checkpoint_index=0 checkpoint=0
+  integer region_count=0 command_count=0 index parse_status
+
+  (( _fsh_incremental_cache_valid )) || return 1
+  [[ -z $prebuffer && $prebuffer == $_fsh_incremental_prebuffer ]] || return 1
+  [[ $buffer != $_fsh_incremental_buffer ]] || return 1
+  [[ $buffer == [[:alnum:][:space:]_./,:@%+\;-]# && $buffer != *';;'* ]] || return 1
+
+  _fsh_incremental_make_fingerprint
+  [[ $REPLY == $_fsh_incremental_fingerprint ]] || return 1
+
+  (( common_limit = $#buffer < $#_fsh_incremental_buffer ? $#buffer : $#_fsh_incremental_buffer ))
+  while (( common < common_limit )) &&
+    [[ ${buffer[common + 1]} == ${_fsh_incremental_buffer[common + 1]} ]]; do
+    (( ++common ))
+  done
+
+  for (( index = 1; index <= $#_fsh_incremental_checkpoints; ++index )); do
+    (( _fsh_incremental_checkpoints[index] <= common )) || break
+    checkpoint_index=$index
+  done
+  (( checkpoint_index )) || return 1
+
+  checkpoint=$_fsh_incremental_checkpoints[checkpoint_index]
+  region_count=$_fsh_incremental_checkpoint_region_counts[checkpoint_index]
+  command_count=$_fsh_incremental_checkpoint_command_counts[checkpoint_index]
+
+  (( region_count )) && prefix_regions=( "${(@)_fsh_incremental_regions[1,region_count]}" )
+  (( command_count )) && {
+    prefix_commands=( "${(@)_fsh_incremental_commands[1,command_count]}" )
+  }
+  _fsh_highlight_init
+  for command in "${prefix_commands[@]}"; do
+    (( ${+checked_commands[(e)$command]} )) && continue
+    checked_commands[(e)$command]=1
+    _fsh_highlight_main_type "$command"
+    [[ $REPLY == ${_fsh_incremental_command_types[(e)$command]-} ]] || return 1
+  done
+  suffix=${buffer[checkpoint + 1,-1]}
+  _fsh_incremental_collect=1
+  _fsh_incremental_parse_safe=1
+  _fsh_incremental_parse_checkpoints=()
+  _fsh_incremental_parse_region_counts=()
+  _fsh_incremental_parse_command_counts=()
+  reply=()
+  if _fsh_highlight_process '' "$suffix" "$checkpoint"; then
+    parse_status=0
+  else
+    parse_status=$?
+  fi
+  _fsh_incremental_collect=0
+
+  (( parse_status == 0 && _fsh_incremental_parse_safe )) || return 1
+  suffix_regions=( "${reply[@]}" )
+  suffix_commands=( "${_fsh_last_commands[@]}" )
+  reply=( "${prefix_regions[@]}" "${suffix_regions[@]}" )
+  _fsh_last_commands=( "${prefix_commands[@]}" "${suffix_commands[@]}" )
+
+  retained_checkpoints=( "${(@)_fsh_incremental_checkpoints[1,checkpoint_index]}" )
+  retained_region_counts=( "${(@)_fsh_incremental_checkpoint_region_counts[1,checkpoint_index]}" )
+  retained_command_counts=( "${(@)_fsh_incremental_checkpoint_command_counts[1,checkpoint_index]}" )
+  _fsh_incremental_checkpoints=( "${retained_checkpoints[@]}" )
+  _fsh_incremental_checkpoint_region_counts=( "${retained_region_counts[@]}" )
+  _fsh_incremental_checkpoint_command_counts=( "${retained_command_counts[@]}" )
+  for (( index = 1; index <= $#_fsh_incremental_parse_checkpoints; ++index )); do
+    _fsh_incremental_checkpoints+=( $_fsh_incremental_parse_checkpoints[index] )
+    _fsh_incremental_checkpoint_region_counts+=( $(( region_count + _fsh_incremental_parse_region_counts[index] )) )
+    _fsh_incremental_checkpoint_command_counts+=( $(( command_count + _fsh_incremental_parse_command_counts[index] )) )
+  done
+
+  _fsh_incremental_buffer=$buffer
+  _fsh_incremental_regions=( "${reply[@]}" )
+  _fsh_incremental_commands=( "${_fsh_last_commands[@]}" )
+  _fsh_incremental_capture_command_types
+  _fsh_incremental_last_used=1
+  return 0
+}
+
+_fsh_highlight_buffer() {
+  builtin emulate -L zsh
+  builtin setopt extended_glob
+
+  local prebuffer=$1 buffer=$2
+  integer parse_status
+
+  _fsh_incremental_last_used=0
+  _fsh_incremental_try "$prebuffer" "$buffer" && return 0
+
+  _fsh_highlight_init
+  if [[ -z $prebuffer && $buffer == [[:alnum:][:space:]_./,:@%+\;-]# &&
+    $buffer != *';;'* ]]; then
+    _fsh_incremental_collect=1
+    _fsh_incremental_parse_safe=1
+  else
+    _fsh_incremental_collect=0
+    _fsh_incremental_parse_safe=0
+  fi
+  _fsh_incremental_parse_checkpoints=()
+  _fsh_incremental_parse_region_counts=()
+  _fsh_incremental_parse_command_counts=()
+  reply=()
+  if _fsh_highlight_process "$prebuffer" "$buffer" 0; then
+    parse_status=0
+  else
+    parse_status=$?
+  fi
+  _fsh_incremental_collect=0
+  if (( parse_status != 0 )); then
+    _fsh_incremental_reset
+    return $parse_status
+  fi
+  _fsh_incremental_store_full "$prebuffer" "$buffer"
 }
 
 typeset -ga _fsh_style_ranges

--- a/tests/integration/test-highlight-budget.zsh
+++ b/tests/integration/test-highlight-budget.zsh
@@ -17,48 +17,100 @@ zstyle ':fsh:config' bracket-highlighting disabled
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
 
-integer -r buffer_length=1000
 float -r budget_seconds=0.250
-integer run
-float started elapsed median
+float -r incremental_ratio=0.700
+integer length run
+float started elapsed full_median incremental_median
 typeset pattern='echo a; '
 typeset BUFFER= PREBUFFER=
+typeset suffix_char
 typeset -a reply samples
+typeset -A full_medians incremental_medians
 
-(( _fsh_max_length == buffer_length ))
+(( _fsh_max_length == 1000 ))
 
-while (( $#BUFFER < buffer_length )); do
-  BUFFER+=$pattern
-done
-BUFFER=${BUFFER[1,buffer_length]}
-(( $#BUFFER == buffer_length ))
+# Compare full parses with eligible end edits across short, medium, and capped
+# buffers. Medians tolerate an isolated noisy runner while preserving a fixed
+# per-keystroke ceiling at the configured cap.
+for length in 100 500 1000; do
+  BUFFER=
+  while (( $#BUFFER < length )); do
+    BUFFER+=$pattern
+  done
+  BUFFER=${BUFFER[1,length]}
+  (( $#BUFFER == length ))
 
-# Warm caches before collecting five samples. The median tolerates an isolated
-# noisy runner while preserving a fixed per-keystroke regression ceiling.
-_fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
-(( $#reply > 0 ))
-
-for run in {1..5}; do
-  reply=()
-  started=$EPOCHREALTIME
   _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
-  elapsed=$(( EPOCHREALTIME - started ))
-  samples+=( $elapsed )
   (( $#reply > 0 ))
+  samples=()
+  for run in {1..5}; do
+    _fsh_incremental_reset
+    started=$EPOCHREALTIME
+    _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
+    elapsed=$(( EPOCHREALTIME - started ))
+    samples+=( $elapsed )
+    (( ! _fsh_incremental_last_used ))
+    (( $#reply > 0 ))
+  done
+  samples=( ${(on)samples} )
+  full_median=$samples[3]
+  full_medians[$length]=$full_median
+
+  _fsh_incremental_reset
+  _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
+  samples=()
+  for run in {1..5}; do
+    (( run % 2 )) && suffix_char=x || suffix_char=y
+    BUFFER=${BUFFER[1,-2]}$suffix_char
+    started=$EPOCHREALTIME
+    _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
+    elapsed=$(( EPOCHREALTIME - started ))
+    samples+=( $elapsed )
+    (( _fsh_incremental_last_used ))
+    (( $#reply > 0 ))
+  done
+  samples=( ${(on)samples} )
+  incremental_median=$samples[3]
+  incremental_medians[$length]=$incremental_median
+
+  if [[ -n ${FSH_BENCHMARK_REPORT-} ]]; then
+    builtin printf \
+      'f-sy-h: %d chars full=%.6fs incremental=%.6fs ratio=%.3f\n' \
+      $length $full_median $incremental_median \
+      $(( incremental_median / full_median ))
+  fi
 done
 
-samples=( ${(on)samples} )
-median=$samples[3]
-if (( median > budget_seconds )); then
+full_median=$full_medians[1000]
+incremental_median=$incremental_medians[1000]
+if (( full_median > budget_seconds )); then
   builtin printf >&2 \
-    'f-sy-h: median highlight time %.3fs exceeds %.3fs at %d characters\n' \
-    $median $budget_seconds $buffer_length
+    'f-sy-h: median full highlight time %.3fs exceeds %.3fs at 1000 characters\n' \
+    $full_median $budget_seconds
+  exit 1
+fi
+if (( incremental_median > budget_seconds )); then
+  builtin printf >&2 \
+    'f-sy-h: median incremental highlight time %.3fs exceeds %.3fs at 1000 characters\n' \
+    $incremental_median $budget_seconds
+  exit 1
+fi
+if (( incremental_median > full_median * incremental_ratio )); then
+  builtin printf >&2 \
+    'f-sy-h: median incremental time %.3fs is not at least 30%% faster than %.3fs at 1000 characters\n' \
+    $incremental_median $full_median
   exit 1
 fi
 
-BUFFER+=x
+BUFFER=
+while (( $#BUFFER <= _fsh_max_length )); do
+  BUFFER+=$pattern
+done
+BUFFER=${BUFFER[1,_fsh_max_length + 1]}
+(( $#BUFFER == _fsh_max_length + 1 ))
 region_highlight=( sentinel )
 _fsh_zle_highlight
 [[ $region_highlight == sentinel ]]
+(( ! _fsh_incremental_cache_valid ))
 
 fsh_plugin_unload

--- a/tests/integration/test-incremental-highlighting.zsh
+++ b/tests/integration/test-incremental-highlighting.zsh
@@ -1,0 +1,178 @@
+#!/usr/bin/env zsh
+
+emulate -R zsh
+setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-incremental.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset -gx ZDOTDIR=$fixture_root/zdotdir
+typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+command mkdir -p -- "$ZDOTDIR"
+zstyle ':fsh:config' work-dir "$fixture_root/work"
+zstyle ':fsh:config' bracket-highlighting disabled
+
+source "$plugin_root/F-Sy-H.plugin.zsh"
+
+typeset -a reply expected_regions actual_regions
+
+full_regions() {
+  emulate -L zsh
+
+  _fsh_highlight_init
+  reply=()
+  _fsh_highlight_process '' "$1" 0
+  expected_regions=( "${reply[@]}" )
+}
+
+assert_regions() {
+  emulate -L zsh
+
+  local buffer=$1
+  integer expected_incremental=$2 actual_incremental
+
+  _fsh_highlight_buffer '' "$buffer"
+  actual_incremental=$_fsh_incremental_last_used
+  actual_regions=( "${reply[@]}" )
+  full_regions "$buffer"
+
+  [[ ${(F)actual_regions} == ${(F)expected_regions} ]] || {
+    builtin print -u2 -r -- "f-sy-h: incremental region mismatch for ${(qqq)buffer}"
+    builtin print -u2 -r -- "expected: ${(qqq)expected_regions}"
+    builtin print -u2 -r -- "actual:   ${(qqq)actual_regions}"
+    return 1
+  }
+  (( actual_incremental == expected_incremental )) || {
+    builtin print -u2 -r -- \
+      "f-sy-h: incremental=$actual_incremental, expected $expected_incremental for ${(qqq)buffer}"
+    return 1
+  }
+}
+
+prime_cache() {
+  emulate -L zsh
+
+  _fsh_incremental_reset
+  _fsh_highlight_buffer '' "$1"
+  (( ! _fsh_incremental_last_used ))
+  (( _fsh_incremental_cache_valid ))
+  (( $#_fsh_incremental_checkpoints ))
+}
+
+typeset old_buffer='echo a; echo b; echo c'
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b; echo cx' 1
+
+prime_cache 'echo a; echo b; echo cxx'
+assert_regions 'echo a; echo b; echo c' 1
+
+prime_cache 'echo a; '
+assert_regions 'echo a;' 1
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo bx; echo c' 1
+
+prime_cache $'echo a\necho b\necho c'
+assert_regions $'echo a\necho b\necho cx' 1
+
+prime_cache "$old_buffer"
+assert_regions 'xecho a; echo b; echo c' 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a echo b; echo c' 0
+
+prime_cache "$old_buffer"
+assert_regions "echo a; echo b; echo 'c'" 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b; echo c >out' 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b; value=1' 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b; if true; then echo c; fi' 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b;; echo c' 0
+
+prime_cache "$old_buffer"
+assert_regions 'echo a; echo b; echo snowman-☃' 0
+
+prime_cache "$old_buffer"
+typeset original_command_style=${_fsh_styles[command]}
+_fsh_styles[command]=fg=123
+assert_regions 'echo a; echo b; echo cx' 0
+_fsh_styles[command]=$original_command_style
+
+prime_cache "$old_buffer"
+alias -g b='global-value'
+assert_regions 'echo a; echo b; echo cx' 0
+unalias 'b'
+
+prime_cache 'cachecmd a; echo c'
+alias cachecmd=echo
+assert_regions 'cachecmd a; echo cx' 0
+unalias cachecmd
+
+prime_cache "$old_buffer"
+_fsh_highlight_buffer $'echo prior\n' 'echo c'
+(( ! _fsh_incremental_last_used ))
+(( ! _fsh_incremental_cache_valid ))
+
+prime_cache "$old_buffer"
+_fsh_incremental_reset
+(( ! _fsh_incremental_cache_valid ))
+
+prime_cache "$old_buffer"
+typeset -g BUFFER=$old_buffer
+typeset -gi CURSOR=1 REGION_ACTIVE=0
+typeset -g _fsh_prior_buffer=$BUFFER _fsh_prior_region_active=$REGION_ACTIVE
+typeset -gi _fsh_prior_cursor=0
+! _fsh_buffer_modified
+(( _fsh_incremental_cache_valid ))
+
+typeset random_prefix='echo a; echo b; echo '
+typeset random_tail=seed random_char left right
+typeset random_buffer=$random_prefix$random_tail
+typeset -a alphabet=( {a..z} )
+integer action position run
+RANDOM=9301
+prime_cache "$random_buffer"
+for run in {1..100}; do
+  action=$(( RANDOM % 3 ))
+  random_char=$alphabet[$(( RANDOM % $#alphabet + 1 ))]
+  case $action in
+    (0)
+      position=$(( RANDOM % ($#random_tail + 1) ))
+      if (( position == 0 )); then
+        random_tail=$random_char$random_tail
+      elif (( position == $#random_tail )); then
+        random_tail+=$random_char
+      else
+        random_tail=${random_tail[1,position]}$random_char${random_tail[position + 1,-1]}
+      fi
+      ;;
+    (1)
+      if (( $#random_tail > 1 )); then
+        position=$(( RANDOM % $#random_tail + 1 ))
+        left=${random_tail[1,position - 1]}
+        right=${random_tail[position + 1,-1]}
+        random_tail=$left$right
+      else
+        random_tail+=$random_char
+      fi
+      ;;
+    (2)
+      position=$(( RANDOM % $#random_tail + 1 ))
+      left=${random_tail[1,position - 1]}
+      right=${random_tail[position + 1,-1]}
+      random_tail=$left$random_char$right
+      ;;
+  esac
+  random_buffer=$random_prefix$random_tail
+  assert_regions "$random_buffer" 1
+done
+
+fsh_plugin_unload


### PR DESCRIPTION
## Summary

- record parser-confirmed checkpoints for independent simple command lists
- reuse cached prefix regions only when buffer, theme, command types, aliases, paths, and ZLE context remain compatible
- fall back to the existing full parser for quoting, redirections, assignments, aliases, chroma, control structures, multiline `PREBUFFER`, and ambiguous edits
- retain full bracket and string scanning plus the existing skip behavior above the 1,000-character cap

## Verification

- all integration profiles passed, including interactive and non-interactive lifecycle coverage
- incremental output matched ordered full-parse regions for targeted cases and 100 seeded edits
- ZUnit 0.8.2 passed 21 of 21 tests
- all 12 shipped themes passed schema validation
- syntax validation and `git diff --check` passed
- Trunk reported no findings for available linters; the local Trunk-managed `gitleaks` binary was unavailable

Current comparative medians:

| Buffer | Full | Incremental | Ratio |
| ---: | ---: | ---: | ---: |
| 100 characters | 0.038494 s | 0.038034 s | 0.988 |
| 500 characters | 0.061987 s | 0.043247 s | 0.698 |
| 1,000 characters | 0.091945 s | 0.049742 s | 0.541 |

The 1,000-character incremental path is approximately 46 percent faster while both paths remain below the 250 ms ceiling.

Closes #93
