### PR TITLE
perf: reduce incremental validation overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,12 @@ zsh -f tools/validate-themes.zsh
 zunit
 ```
 
-The highlight-budget profile compares five full parses and five eligible end
-edits at 100, 500, and 1,000 characters. At 1,000 characters, both medians must
-remain at or below 250 ms and the incremental median must be at least 30 percent
-faster. A buffer above the default limit must take the skip path. The
-incremental-highlighting profile compares ordered regions with full parses for
-targeted invalidation cases and 100 seeded edits.
+The highlight-budget profile compares nine interleaved pairs of full parses and
+eligible end edits at 100, 500, and 1,000 characters. At 1,000 characters, both
+medians must remain at or below 250 ms and the median paired ratio must show at
+least a 30 percent improvement. A buffer above the default limit must take the
+skip path. The incremental-highlighting profile compares ordered regions with
+full parses for targeted invalidation cases and 100 seeded edits.
 
 `tools/validate-themes.zsh` validates all shipped themes by default and accepts
 explicit INI paths as arguments. It emits one JSON Lines record per result or

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -1582,9 +1582,10 @@ _fsh_incremental_capture_command_types() {
   builtin emulate -L zsh
 
   local command
+  local -aU unique_commands
   _fsh_incremental_command_types=()
-  for command in "${_fsh_incremental_commands[@]}"; do
-    (( ${+_fsh_incremental_command_types[(e)$command]} )) && continue
+  unique_commands=( "${_fsh_incremental_commands[@]}" )
+  for command in "${unique_commands[@]}"; do
     _fsh_highlight_main_type "$command"
     _fsh_incremental_command_types[(e)$command]=$REPLY
   done
@@ -1621,7 +1622,7 @@ _fsh_incremental_try() {
   local prebuffer=$1 buffer=$2 suffix command
   local -a prefix_regions prefix_commands suffix_regions suffix_commands
   local -a retained_checkpoints retained_region_counts retained_command_counts
-  local -A checked_commands
+  local -aU unique_prefix_commands
   integer common=0 common_limit checkpoint_index=0 checkpoint=0
   integer region_count=0 command_count=0 index parse_status
 
@@ -1654,9 +1655,8 @@ _fsh_incremental_try() {
     prefix_commands=( "${(@)_fsh_incremental_commands[1,command_count]}" )
   }
   _fsh_highlight_init
-  for command in "${prefix_commands[@]}"; do
-    (( ${+checked_commands[(e)$command]} )) && continue
-    checked_commands[(e)$command]=1
+  unique_prefix_commands=( "${prefix_commands[@]}" )
+  for command in "${unique_prefix_commands[@]}"; do
     _fsh_highlight_main_type "$command"
     [[ $REPLY == ${_fsh_incremental_command_types[(e)$command]-} ]] || return 1
   done

--- a/tests/integration/test-highlight-budget.zsh
+++ b/tests/integration/test-highlight-budget.zsh
@@ -20,18 +20,19 @@ source "$plugin_root/F-Sy-H.plugin.zsh"
 float -r budget_seconds=0.250
 float -r incremental_ratio=0.700
 integer length run
-float started elapsed full_median incremental_median
+float started full_elapsed incremental_elapsed
+float full_median incremental_median paired_median
 typeset pattern='echo a; '
 typeset BUFFER= PREBUFFER=
 typeset suffix_char
-typeset -a reply samples
-typeset -A full_medians incremental_medians
+typeset -a reply full_samples incremental_samples paired_samples
+typeset -A full_medians incremental_medians paired_medians
 
 (( _fsh_max_length == 1000 ))
 
-# Compare full parses with eligible end edits across short, medium, and capped
-# buffers. Medians tolerate an isolated noisy runner while preserving a fixed
-# per-keystroke ceiling at the configured cap.
+# Interleave full parses with eligible end edits across short, medium, and
+# capped buffers. Paired ratios remove phase-to-phase runner drift while
+# medians tolerate an isolated noisy pair.
 for length in 100 500 1000; do
   BUFFER=
   while (( $#BUFFER < length )); do
@@ -42,47 +43,49 @@ for length in 100 500 1000; do
 
   _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
   (( $#reply > 0 ))
-  samples=()
-  for run in {1..5}; do
+  full_samples=()
+  incremental_samples=()
+  paired_samples=()
+  for run in {1..9}; do
     _fsh_incremental_reset
     started=$EPOCHREALTIME
     _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
-    elapsed=$(( EPOCHREALTIME - started ))
-    samples+=( $elapsed )
+    full_elapsed=$(( EPOCHREALTIME - started ))
+    full_samples+=( $full_elapsed )
     (( ! _fsh_incremental_last_used ))
     (( $#reply > 0 ))
-  done
-  samples=( ${(on)samples} )
-  full_median=$samples[3]
-  full_medians[$length]=$full_median
 
-  _fsh_incremental_reset
-  _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
-  samples=()
-  for run in {1..5}; do
     (( run % 2 )) && suffix_char=x || suffix_char=y
     BUFFER=${BUFFER[1,-2]}$suffix_char
     started=$EPOCHREALTIME
     _fsh_highlight_buffer "$PREBUFFER" "$BUFFER"
-    elapsed=$(( EPOCHREALTIME - started ))
-    samples+=( $elapsed )
+    incremental_elapsed=$(( EPOCHREALTIME - started ))
+    incremental_samples+=( $incremental_elapsed )
+    paired_samples+=( $(( incremental_elapsed / full_elapsed )) )
     (( _fsh_incremental_last_used ))
     (( $#reply > 0 ))
   done
-  samples=( ${(on)samples} )
-  incremental_median=$samples[3]
+
+  full_samples=( ${(on)full_samples} )
+  incremental_samples=( ${(on)incremental_samples} )
+  paired_samples=( ${(on)paired_samples} )
+  full_median=$full_samples[5]
+  incremental_median=$incremental_samples[5]
+  paired_median=$paired_samples[5]
+  full_medians[$length]=$full_median
   incremental_medians[$length]=$incremental_median
+  paired_medians[$length]=$paired_median
 
   if [[ -n ${FSH_BENCHMARK_REPORT-} ]]; then
     builtin printf \
-      'f-sy-h: %d chars full=%.6fs incremental=%.6fs ratio=%.3f\n' \
-      $length $full_median $incremental_median \
-      $(( incremental_median / full_median ))
+      'f-sy-h: %d chars full=%.6fs incremental=%.6fs paired-ratio=%.3f\n' \
+      $length $full_median $incremental_median $paired_median
   fi
 done
 
 full_median=$full_medians[1000]
 incremental_median=$incremental_medians[1000]
+paired_median=$paired_medians[1000]
 if (( full_median > budget_seconds )); then
   builtin printf >&2 \
     'f-sy-h: median full highlight time %.3fs exceeds %.3fs at 1000 characters\n' \
@@ -95,10 +98,10 @@ if (( incremental_median > budget_seconds )); then
     $incremental_median $budget_seconds
   exit 1
 fi
-if (( incremental_median > full_median * incremental_ratio )); then
+if (( paired_median > incremental_ratio )); then
   builtin printf >&2 \
-    'f-sy-h: median incremental time %.3fs is not at least 30%% faster than %.3fs at 1000 characters\n' \
-    $incremental_median $full_median
+    'f-sy-h: median paired incremental/full ratio %.3f exceeds %.3f at 1000 characters\n' \
+    $paired_median $incremental_ratio
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- deduplicate cached and prefix command-type validation before entering the Zsh loop
- interleave nine full and incremental measurements per buffer size
- enforce the unchanged 30 percent improvement requirement using the median paired ratio
- retain the unchanged 250 ms full and incremental ceilings at 1,000 characters

## Background

The post-merge ZUnit run on `main` failed only on macOS because the phase-separated benchmark measured 0.040s incremental against 0.056s full, a ratio of about 0.714. The two measurement phases were vulnerable to runner drift. See [run 33288808700](https://github.com/z-shell/F-Sy-H/actions/runs/33288808700).

## Verification

- all 15 integration profiles pass, including both lifecycle modes and exact incremental/full region equivalence
- five additional independent benchmark processes pass; 1,000-character paired median ratios ranged from 0.474 to 0.552 under concurrent load
- ZUnit 0.8.2 passes 21/21
- all 12 shipped themes validate
- repository-wide Zsh syntax checks pass
- Trunk reports no issues on the three modified files, excluding only the unavailable local managed gitleaks binary
- `git diff --check` passes

Closes #93
