### PR TITLE
feat(themes): enforce shipped theme contrast

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -406,7 +406,8 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 builtin autoload -Uz -- is-at-least \
-  _fsh_read_ini _fsh_validate_theme _fsh_run_git_command \
+  _fsh_read_ini _fsh_theme_color_rgb _fsh_validate_theme_contrast \
+  _fsh_validate_theme _fsh_run_git_command \
   _fsh_make_targets _fsh_run_command _fsh_read_all \
   _fsh_async_command _fsh_async_command_callback
 
@@ -505,9 +506,9 @@ fi
   _fsh_styles[defaultsubtle-bg]="bg=blue"
   [[ "${_fsh_styles[variable]}" = "fg=113" ]] && _fsh_styles[variable]="none"
   [[ "${_fsh_styles[globbing-ext]}" = "fg=13" ]] && _fsh_styles[globbing-ext]="fg=blue,bold"
-  [[ "${_fsh_styles[here-string-text]}" = "bg=18" ]] && _fsh_styles[here-string-text]="bg=blue"
+  [[ "${_fsh_styles[here-string-text]}" = "fg=69" ]] && _fsh_styles[here-string-text]="bg=blue"
   [[ "${_fsh_styles[here-string-var]}" = "fg=cyan,bg=18" ]] && _fsh_styles[here-string-var]="fg=cyan,bg=blue"
-  [[ "${_fsh_styles[correct-subtle]}" = "fg=12" ]] && _fsh_styles[correct-subtle]="bg=blue"
+  [[ "${_fsh_styles[correct-subtle]}" = "fg=69" ]] && _fsh_styles[correct-subtle]="bg=blue"
   [[ "${_fsh_styles[subtle-bg]}" = "bg=18" ]] && _fsh_styles[subtle-bg]="bg=blue"
 }
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ explicit INI paths as arguments. It emits one JSON Lines record per result or
 diagnostic using schema `fsh-theme-validation/v1`, and exits non-zero if any
 record has `status` set to `error`.
 
+Every shipped theme declares a `[theme]` rendering contract. Fixed-palette
+themes use `palette = xterm-256` with exact `foreground` and `background`
+`#rrggbb` values. Their resolved ordinary styles must reach a contrast ratio of
+4.5:1; `unknown-token`, `incorrect-subtle`, and `matherr` must reach 7:1.
+`palette = terminal-ansi16` is adaptive and restricts colors to terminal-owned
+ANSI indices 0 through 15 instead of claiming a fixed contrast ratio. Metadata
+remains optional for external themes, preserving existing user themes; when it
+is present, the same validation contract applies.
+
 The ZUnit command requires the repository's pinned ZUnit toolchain.
 
 ## Documentation and support

--- a/functions/_fsh_theme_color_rgb
+++ b/functions/_fsh_theme_color_rgb
@@ -1,0 +1,56 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Resolve one color through the canonical xterm-256 reference palette.
+#
+# $1 - named, indexed, or #rrggbb color
+# $2 - palette name
+#
+# Result: reply=( red green blue ) with integer channels from 0 through 255.
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local color=$1 palette=$2 hex
+local -A named=(
+  black 0 red 1 green 2 yellow 3 blue 4 magenta 5 cyan 6 white 7
+)
+local -a ansi=(
+  0 0 0       205 0 0     0 205 0     205 205 0
+  0 0 238     205 0 205   0 205 205   229 229 229
+  127 127 127 255 0 0     0 255 0     255 255 0
+  92 92 255   255 0 255   0 255 255   255 255 255
+)
+local -a levels=( 0 95 135 175 215 255 )
+integer index offset red green blue
+
+reply=()
+[[ $palette == xterm-256 ]] || return 1
+
+if [[ $color == \#[0-9a-fA-F](#c6,6) ]]; then
+  hex=${color#\#}
+  reply=( $(( 16#${hex[1,2]} )) $(( 16#${hex[3,4]} )) $(( 16#${hex[5,6]} )) )
+  return 0
+fi
+
+if (( ${+named[$color]} )); then
+  index=$named[$color]
+elif [[ $color == (0|[1-9][0-9]#) ]] && (( color <= 255 )); then
+  index=$color
+else
+  return 1
+fi
+
+if (( index < 16 )); then
+  offset=$(( index * 3 + 1 ))
+  reply=( ${ansi[offset]} ${ansi[offset + 1]} ${ansi[offset + 2]} )
+elif (( index < 232 )); then
+  offset=$(( index - 16 ))
+  red=$(( offset / 36 + 1 ))
+  green=$(( (offset % 36) / 6 + 1 ))
+  blue=$(( offset % 6 + 1 ))
+  reply=( ${levels[red]} ${levels[green]} ${levels[blue]} )
+else
+  offset=$(( 8 + (index - 232) * 10 ))
+  reply=( $offset $offset $offset )
+fi

--- a/functions/_fsh_validate_theme
+++ b/functions/_fsh_validate_theme
@@ -5,6 +5,7 @@
 #
 # $1 - theme INI path
 # $2 - shipped theme directory, used to resolve secondary theme names
+# $3 - optional full, overlay, or shipped validation mode
 #
 # Results:
 # - _fsh_validated_theme_data: parsed INI records
@@ -14,10 +15,10 @@
 builtin emulate -L zsh
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
-local theme_path=$1 theme_dir=$2 validation_mode=${3:-} full_key declared_key style candidate inikey value token
-local secondary_key secondary_name secondary_path required_key error
-local -A known declared_seen
-local -a candidates style_colors
+local theme_path=$1 theme_dir=$2 validation_mode=${3:-} style_mode full_key declared_key style candidate inikey value token
+local secondary_key secondary_name secondary_path required_key error metadata_key palette foreground background
+local -A known declared_seen metadata_seen
+local -a candidates style_colors metadata_keys
 
 typeset -gA _fsh_validated_theme_data=()
 typeset -ga _fsh_theme_validation_errors=()
@@ -26,10 +27,11 @@ typeset -gi _fsh_theme_declared_count=0 _fsh_theme_resolved_count=0
 if [[ -z $validation_mode ]]; then
   [[ ${theme_path:t:r} == *overlay* ]] && validation_mode=overlay || validation_mode=full
 fi
-[[ $validation_mode == (full|overlay) ]] || {
+[[ $validation_mode == (full|overlay|shipped) ]] || {
   _fsh_theme_validation_errors+=( "invalid-mode|unknown theme validation mode: $validation_mode" )
   return 1
 }
+[[ $validation_mode == shipped ]] && style_mode=full || style_mode=$validation_mode
 
 _fsh_read_ini "$theme_path" _fsh_validated_theme_data '' || {
   for error in "${_fsh_ini_errors[@]}"; do
@@ -39,6 +41,7 @@ _fsh_read_ini "$theme_path" _fsh_validated_theme_data '' || {
 }
 
 style_colors=( red green blue yellow cyan magenta black white default )
+metadata_keys=( "${_fsh_theme_metadata_keys[@]}" )
 for style in "${_fsh_theme_style_order[@]}"; do
   known[$style]=1
   for candidate in ${(s. .)_fsh_theme_style_fallbacks[$style]}; do
@@ -50,6 +53,15 @@ known[secondary]=1
 
 for full_key in ${(k)_fsh_validated_theme_data}; do
   declared_key=${full_key#*>_}
+  if [[ $full_key == '<theme>_'* ]]; then
+    if (( ${metadata_keys[(Ie)$declared_key]} )); then
+      metadata_seen[$declared_key]=1
+    else
+      _fsh_theme_validation_errors+=(
+        "unknown-theme-metadata|unknown [theme] declaration: $declared_key" )
+    fi
+    continue
+  fi
   if (( ! ${+known[$declared_key]} )); then
     _fsh_theme_validation_errors+=( "unknown-style|unknown style declaration: $declared_key" )
     continue
@@ -78,7 +90,7 @@ for full_key in ${(k)_fsh_validated_theme_data}; do
   done
 done
 
-if [[ $validation_mode == full ]]; then
+if [[ $style_mode == full ]]; then
   for style in "${_fsh_theme_style_order[@]}"; do
     [[ $style == secondary ]] && continue
     candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
@@ -99,6 +111,67 @@ if [[ $validation_mode == full ]]; then
       _fsh_theme_validation_errors+=( "unresolved-style|cannot resolve style: $style" )
     fi
   done
+fi
+
+palette=${_fsh_validated_theme_data[<theme>_palette]-}
+foreground=${_fsh_validated_theme_data[<theme>_foreground]-}
+background=${_fsh_validated_theme_data[<theme>_background]-}
+if [[ $validation_mode == shipped ]]; then
+  for metadata_key in "${metadata_keys[@]}"; do
+    (( ${+metadata_seen[$metadata_key]} )) ||
+      _fsh_theme_validation_errors+=(
+        "missing-theme-metadata|missing [theme] declaration: $metadata_key" )
+  done
+fi
+
+if (( $#metadata_seen && $#metadata_seen < $#metadata_keys )) &&
+  [[ $validation_mode != shipped ]]; then
+  for metadata_key in "${metadata_keys[@]}"; do
+    (( ${+metadata_seen[$metadata_key]} )) ||
+      _fsh_theme_validation_errors+=(
+        "incomplete-theme-metadata|missing [theme] declaration: $metadata_key" )
+  done
+fi
+
+if (( $#metadata_seen == $#metadata_keys )); then
+  [[ $palette == (xterm-256|terminal-ansi16) ]] ||
+    _fsh_theme_validation_errors+=(
+      "invalid-theme-palette|unknown theme palette: $palette" )
+
+  if [[ $palette == xterm-256 ]]; then
+    [[ $foreground == \#[0-9a-fA-F](#c6,6) ]] ||
+      _fsh_theme_validation_errors+=(
+        "invalid-theme-color|theme foreground must be an exact #rrggbb color" )
+    [[ $background == \#[0-9a-fA-F](#c6,6) ]] ||
+      _fsh_theme_validation_errors+=(
+        "invalid-theme-color|theme background must be an exact #rrggbb color" )
+    if [[ $style_mode == full && $foreground == \#[0-9a-fA-F](#c6,6) &&
+      $background == \#[0-9a-fA-F](#c6,6) ]]; then
+      _fsh_validate_theme_contrast "$palette" "$foreground" "$background"
+    fi
+  elif [[ $palette == terminal-ansi16 ]]; then
+    [[ $foreground == default && $background == default ]] ||
+      _fsh_theme_validation_errors+=(
+        "invalid-theme-color|terminal-ansi16 foreground and background must be default" )
+    if [[ $style_mode == full ]]; then
+      for full_key in ${(k)_fsh_validated_theme_data}; do
+        [[ $full_key == '<theme>_'* ]] && continue
+        declared_key=${full_key#*>_}
+        [[ $declared_key == secondary ]] && continue
+        value=${_fsh_validated_theme_data[$full_key]}
+        for token in ${(s:,:)value}; do
+          [[ $token == bg:* ]] && token=${token#bg:}
+          [[ $token == (none|(no-|)(bold|blink|conceal|reverse|standout|underline)|default) ||
+            $token == (${(~j:|:)style_colors}) ]] && continue
+          if [[ $token == (0|[1-9][0-9]#) ]] && (( token <= 15 )); then
+            continue
+          fi
+          _fsh_theme_validation_errors+=(
+            "adaptive-palette-out-of-range|$declared_key uses color outside terminal ANSI 0-15: $token" )
+        done
+      done
+    fi
+  fi
 fi
 
 secondary_key=${_fsh_validated_theme_data[(i)<*>_secondary]}

--- a/functions/_fsh_validate_theme_contrast
+++ b/functions/_fsh_validate_theme_contrast
@@ -1,0 +1,112 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Apply the contrast contract to parsed, fully resolved theme data.
+#
+# $1 - palette name
+# $2 - declared default foreground
+# $3 - declared default background
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local palette=$1 default_foreground=$2 default_background=$3
+local style candidate inikey value token foreground background minimum contrast_text
+local -a candidates reply foreground_rgb background_rgb
+integer reverse component
+float foreground_luminance background_luminance lighter darker contrast channel linear
+
+for style in "${_fsh_theme_style_order[@]}"; do
+  [[ $style == secondary ]] && continue
+
+  candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
+  inikey=
+  for candidate in "${candidates[@]}"; do
+    [[ $candidate == - ]] && candidate=$style
+    inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
+    [[ -n $inikey ]] && break
+  done
+  [[ -n $inikey ]] || continue
+
+  value=${_fsh_validated_theme_data[$inikey]}
+  foreground=$default_foreground
+  background=$default_background
+  reverse=0
+  for token in ${(s:,:)value}; do
+    case $token in
+      (none)
+        foreground=$default_foreground
+        background=$default_background
+        reverse=0
+        ;;
+      (reverse) reverse=1 ;;
+      (no-reverse) reverse=0 ;;
+      (bg:*) background=${token#bg:} ;;
+      ((no-|)(bold|blink|conceal|standout|underline)) ;;
+      (*) foreground=$token ;;
+    esac
+  done
+  if (( reverse )); then
+    candidate=$foreground
+    foreground=$background
+    background=$candidate
+  fi
+  [[ $foreground == default ]] && foreground=$default_foreground
+  [[ $background == default ]] && background=$default_background
+
+  _fsh_theme_color_rgb "$foreground" "$palette" || continue
+  foreground_rgb=( "${reply[@]}" )
+  _fsh_theme_color_rgb "$background" "$palette" || continue
+  background_rgb=( "${reply[@]}" )
+
+  foreground_luminance=0.0
+  for candidate in 1 2 3; do
+    component=${foreground_rgb[candidate]}
+    (( channel = component / 255.0 ))
+    if (( channel <= 0.04045 )); then
+      (( linear = channel / 12.92 ))
+    else
+      (( linear = ((channel + 0.055) / 1.055) ** 2.4 ))
+    fi
+    case $candidate in
+      (1) (( foreground_luminance += 0.2126 * linear )) ;;
+      (2) (( foreground_luminance += 0.7152 * linear )) ;;
+      (3) (( foreground_luminance += 0.0722 * linear )) ;;
+    esac
+  done
+
+  background_luminance=0.0
+  for candidate in 1 2 3; do
+    component=${background_rgb[candidate]}
+    (( channel = component / 255.0 ))
+    if (( channel <= 0.04045 )); then
+      (( linear = channel / 12.92 ))
+    else
+      (( linear = ((channel + 0.055) / 1.055) ** 2.4 ))
+    fi
+    case $candidate in
+      (1) (( background_luminance += 0.2126 * linear )) ;;
+      (2) (( background_luminance += 0.7152 * linear )) ;;
+      (3) (( background_luminance += 0.0722 * linear )) ;;
+    esac
+  done
+
+  if (( foreground_luminance >= background_luminance )); then
+    lighter=$foreground_luminance
+    darker=$background_luminance
+  else
+    lighter=$background_luminance
+    darker=$foreground_luminance
+  fi
+  (( contrast = (lighter + 0.05) / (darker + 0.05) ))
+  minimum=$_fsh_theme_contrast_floor
+  (( ${+_fsh_theme_critical_styles[$style]} )) &&
+    minimum=$_fsh_theme_critical_contrast_floor
+  # Compare the unrounded ratio. Formatting is diagnostic output only.
+  if (( contrast < minimum )); then
+    builtin printf -v contrast_text '%.2f' "$contrast"
+    _fsh_theme_validation_errors+=(
+      "contrast-too-low|$style contrast $contrast_text:1 is below ${minimum}:1 ($foreground on $background)"
+    )
+  fi
+done

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -56,7 +56,7 @@ _fsh_work_dir=${~_fsh_work_dir}
 typeset -gA _fsh_styles
 # Built-in theme.
 : ${_fsh_styles[default]:=none}
-: ${_fsh_styles[unknown-token]:=fg=red,bold}
+: ${_fsh_styles[unknown-token]:=fg=210,bold}
 : ${_fsh_styles[reserved-word]:=fg=yellow}
 : ${_fsh_styles[subcommand]:=fg=yellow}
 : ${_fsh_styles[alias]:=fg=green}
@@ -68,17 +68,18 @@ typeset -gA _fsh_styles
 : ${_fsh_styles[precommand]:=fg=green}
 : ${_fsh_styles[commandseparator]:=none}
 : ${_fsh_styles[hashed-command]:=fg=green}
-: ${_fsh_styles[path]:=fg=magenta}
-: ${_fsh_styles[path-to-dir]:=fg=magenta,underline}
+: ${_fsh_styles[path]:=fg=13}
+: ${_fsh_styles[path-to-dir]:=fg=13,underline}
 : ${_fsh_styles[path_pathseparator]:=}
-: ${_fsh_styles[globbing]:=fg=blue,bold}
+: ${_fsh_styles[globbing]:=fg=69,bold}
 : ${_fsh_styles[globbing-ext]:=fg=13}
-: ${_fsh_styles[history-expansion]:=fg=blue,bold}
+: ${_fsh_styles[history-expansion]:=fg=69,bold}
 : ${_fsh_styles[single-hyphen-option]:=fg=cyan}
 : ${_fsh_styles[double-hyphen-option]:=fg=cyan}
 : ${_fsh_styles[back-quoted-argument]:=none}
 : ${_fsh_styles[single-quoted-argument]:=fg=yellow}
 : ${_fsh_styles[double-quoted-argument]:=fg=yellow}
+: ${_fsh_styles[optarg-string]:=fg=yellow}
 : ${_fsh_styles[dollar-quoted-argument]:=fg=yellow}
 : ${_fsh_styles[back-or-dollar-double-quoted-argument]:=fg=cyan}
 : ${_fsh_styles[back-dollar-quoted-argument]:=fg=cyan}
@@ -86,17 +87,19 @@ typeset -gA _fsh_styles
 : ${_fsh_styles[redirection]:=none}
 : ${_fsh_styles[comment]:=fg=243}
 : ${_fsh_styles[variable]:=fg=113}
-: ${_fsh_styles[mathvar]:=fg=blue,bold}
-: ${_fsh_styles[mathnum]:=fg=magenta}
-: ${_fsh_styles[matherr]:=fg=red}
+: ${_fsh_styles[mathvar]:=fg=69,bold}
+: ${_fsh_styles[mathnum]:=fg=13}
+: ${_fsh_styles[optarg-number]:=fg=13}
+: ${_fsh_styles[matherr]:=fg=210}
 : ${_fsh_styles[assign-array-bracket]:=fg=green}
 : ${_fsh_styles[for-loop-variable]:=none}
 : ${_fsh_styles[for-loop-operator]:=fg=yellow}
-: ${_fsh_styles[for-loop-number]:=fg=magenta}
+: ${_fsh_styles[for-loop-number]:=fg=13}
 : ${_fsh_styles[for-loop-separator]:=fg=yellow,bold}
 : ${_fsh_styles[here-string-tri]:=fg=yellow}
-: ${_fsh_styles[here-string-text]:=bg=18}
+: ${_fsh_styles[here-string-text]:=fg=69}
 : ${_fsh_styles[here-string-var]:=fg=cyan,bg=18}
+: ${_fsh_styles[exec-descriptor]:=fg=yellow,bold}
 : ${_fsh_styles[case-input]:=fg=green}
 : ${_fsh_styles[case-parentheses]:=fg=yellow}
 : ${_fsh_styles[case-condition]:=bg=blue}
@@ -107,10 +110,11 @@ typeset -gA _fsh_styles
 : ${_fsh_styles[single-sq-bracket]:=fg=green}
 : ${_fsh_styles[double-sq-bracket]:=fg=green}
 : ${_fsh_styles[double-paren]:=fg=yellow}
-: ${_fsh_styles[correct-subtle]:=fg=12}
-: ${_fsh_styles[incorrect-subtle]:=fg=red}
+: ${_fsh_styles[correct-subtle]:=fg=69}
+: ${_fsh_styles[incorrect-subtle]:=fg=210}
 : ${_fsh_styles[subtle-separator]:=fg=green}
 : ${_fsh_styles[subtle-bg]:=bg=18}
+: ${_fsh_styles[recursive-base]:=none}
 : ${_fsh_styles[secondary]:=free}
 
 _fsh_theme_load_data() {

--- a/lib/theme-schema.zsh
+++ b/lib/theme-schema.zsh
@@ -79,3 +79,15 @@ typeset -ga _fsh_theme_style_order=(
   global-alias subcommand single-sq-bracket double-sq-bracket double-paren
   optarg-string optarg-number recursive-base
 )
+
+# Shipped themes declare their rendering assumptions. External themes may omit
+# this metadata for compatibility, but when it is present the validator applies
+# the same contract used by CI.
+typeset -ga _fsh_theme_metadata_keys=( palette foreground background )
+typeset -g _fsh_theme_contrast_floor=4.5
+typeset -g _fsh_theme_critical_contrast_floor=7.0
+typeset -gA _fsh_theme_critical_styles=(
+  unknown-token     1
+  incorrect-subtle  1
+  matherr           1
+)

--- a/share/free_theme.ini
+++ b/share/free_theme.ini
@@ -7,7 +7,7 @@ freeassign=none
 freeback-dollar-quoted-argument=fg=110
 freeback-or-dollar-double-quoted-argument=fg=110
 freeback-quoted-argument=none
-freebracket-level-1=fg=130
+freebracket-level-1=fg=136
 freebracket-level-2=fg=70
 freebracket-level-3=fg=69
 freebuiltin=fg=180
@@ -37,11 +37,11 @@ freehashed-command=fg=180
 freehere-string-text=bg=19
 freehere-string-tri=fg=yellow
 freehere-string-var=fg=110,bg=19
-freehistory-expansion=fg=blue,bold
+freehistory-expansion=fg=69,bold
 freeincorrect-subtle=bg=52
-freematherr=fg=red
+freematherr=fg=210
 freemathnum=fg=166
-freemathvar=fg=blue,bold
+freemathvar=fg=69,bold
 freeoptarg-number=fg=166
 freeoptarg-string=fg=150
 freepaired-bracket=bg=blue
@@ -60,5 +60,5 @@ freesubcommand=fg=150
 freesubtle-bg=bg=18
 freesubtle-separator=none
 freesuffix-alias=fg=180
-freeunknown-token=fg=red,bold
+freeunknown-token=fg=210,bold
 freevariable=none

--- a/tests/integration/test-git-runtime-knowledge.zsh
+++ b/tests/integration/test-git-runtime-knowledge.zsh
@@ -85,14 +85,21 @@ _fsh_state[chroma-git-options-commit-cache-born-at]=$SECONDS
 typeset -g BUFFER='git commit --future-mode' PREBUFFER=
 reply=()
 _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
-[[ ${(F)reply} == $'0 3 fg=green\n4 10 fg=yellow\n11 24 fg=cyan' ]]
+typeset expected_highlights=
+expected_highlights="0 3 ${_fsh_styles[command]}"$'\n'\
+"4 10 ${_fsh_styles[subcommand]}"$'\n'\
+"11 24 ${_fsh_styles[correct-subtle]}"
+[[ ${(F)reply} == "$expected_highlights" ]]
 [[ ${_fsh_chroma_main_git[subcmd:commit]} == \
   *'GIT_RUNTIME_commit_R_#_opt // NO_MATCH_#_opt'* ]]
 
 BUFFER='git commit --stale-mode'
 reply=()
 _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
-[[ ${(F)reply} == $'0 3 fg=green\n4 10 fg=yellow\n11 23 fg=red' ]]
+expected_highlights="0 3 ${_fsh_styles[command]}"$'\n'\
+"4 10 ${_fsh_styles[subcommand]}"$'\n'\
+"11 23 ${_fsh_styles[incorrect-subtle]}"
+[[ ${(F)reply} == "$expected_highlights" ]]
 
 typeset git_source=$(<"$plugin_root/chroma/_fsh_chroma_git")
 [[ $git_source == *'_fsh_async_command chroma-git-subcommands'* ]]

--- a/tests/integration/test-git-runtime-knowledge.zsh
+++ b/tests/integration/test-git-runtime-knowledge.zsh
@@ -88,7 +88,7 @@ _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0
 typeset expected_highlights=
 expected_highlights="0 3 ${_fsh_styles[command]}"$'\n'\
 "4 10 ${_fsh_styles[subcommand]}"$'\n'\
-"11 24 ${_fsh_styles[correct-subtle]}"
+"11 24 ${_fsh_styles[double-hyphen-option]}"
 [[ ${(F)reply} == "$expected_highlights" ]]
 [[ ${_fsh_chroma_main_git[subcmd:commit]} == \
   *'GIT_RUNTIME_commit_R_#_opt // NO_MATCH_#_opt'* ]]

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -14,6 +14,59 @@ output=$(zsh -f "$plugin_root/tools/validate-themes.zsh")
 [[ $output == *'"schema":"fsh-theme-validation/v1"'* ]]
 [[ $output == *'"declaredStyles":61,"resolvedStyles":60'* ]]
 
+command sed '1,5d' "$plugin_root/themes/clean.ini" >| "$fixture_root/custom-no-metadata.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/custom-no-metadata.ini")
+[[ $output == *'"status":"ok"'* ]]
+
+command sed '/^background = #000000$/d' "$plugin_root/themes/clean.ini" >| \
+  "$fixture_root/incomplete-metadata.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/incomplete-metadata.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: incomplete theme metadata unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"incomplete-theme-metadata"'* ]]
+
+command sed 's/^comment          = 243$/comment          = #000000/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/metadata-contrast-failure.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/metadata-contrast-failure.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: metadata contrast failure unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"contrast-too-low"'*'comment contrast 1.00:1'* ]]
+
+command sed 's/^comment          = 243$/comment          = #747474/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/unrounded-boundary.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/unrounded-boundary.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: sub-4.5 contrast unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'comment contrast 4.49:1 is below 4.5:1'* ]]
+
+command sed 's/^comment          = 243$/comment          = #757575/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/ordinary-boundary-pass.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/ordinary-boundary-pass.ini")
+[[ $output == *'"status":"ok"'* ]]
+
+command sed 's/^unknown-token    = 210,bold$/unknown-token    = #949494,bold/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/critical-boundary-fail.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/critical-boundary-fail.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: sub-7.0 critical contrast unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'unknown-token contrast 6.92:1 is below 7.0:1'* ]]
+
+command sed 's/^unknown-token    = 210,bold$/unknown-token    = #959595,bold/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/critical-boundary-pass.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/critical-boundary-pass.ini")
+[[ $output == *'"status":"ok"'* ]]
+
 command sed \
   -e 's/^command        = 4$/command        = 999/' \
   -e 's/^builtin        = 4$/builtin        = 0300/' \
@@ -27,6 +80,15 @@ fi
 [[ $output == *'"status":"error","code":"invalid-style-value"'* ]]
 [[ $output == *'command has invalid color or style element: 999'* ]]
 [[ $output == *'builtin has invalid color or style element: 0300'* ]]
+
+command sed 's/^command        = 4$/command        = 16/' \
+  "$plugin_root/themes/base16.ini" >| "$fixture_root/adaptive-out-of-range.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/adaptive-out-of-range.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: adaptive palette accepted xterm cube color'
+  exit 1
+fi
+[[ $output == *'"code":"adaptive-palette-out-of-range"'* ]]
 
 {
   builtin print -r -- '[base]'
@@ -48,11 +110,111 @@ output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
   "$fixture_root/sample-overlay.ini")
 [[ $output == *'"status":"ok"'*'"declaredStyles":1,"resolvedStyles":0'* ]]
 
+{
+  builtin print -r -- '[theme]'
+  builtin print -r -- 'palette=xterm-256'
+  builtin print -r -- 'foreground=#ffffff'
+  builtin print -r -- 'background=#000000'
+  builtin print -r -- '[base]'
+  builtin print -r -- 'comment=#000000'
+} >| "$fixture_root/metadata-overlay.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/metadata-overlay.ini")
+[[ $output == *'"status":"ok"'*'"declaredStyles":1,"resolvedStyles":0'* ]]
+
 typeset -gx ZDOTDIR=$fixture_root/zdotdir
 typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
+typeset -gx TERM=xterm-256color
 command mkdir -p -- "$ZDOTDIR"
 zstyle ':fsh:config' work-dir "$fixture_root/work"
+zmodload zsh/termcap
+[[ ${termcap[Co]} == <-> ]] && (( termcap[Co] >= 256 ))
 source "$plugin_root/F-Sy-H.plugin.zsh"
+
+if _fsh_validate_theme "$fixture_root/custom-no-metadata.ini" \
+  "$plugin_root/themes" shipped; then
+  builtin print -u2 -r -- 'f-sy-h: shipped validation accepted missing metadata'
+  exit 1
+fi
+[[ ${_fsh_theme_validation_errors[*]} == *'missing-theme-metadata'* ]]
+
+typeset -a reply
+_fsh_theme_color_rgb 196 xterm-256
+[[ ${reply[*]} == '255 0 0' ]]
+_fsh_theme_color_rgb '#123456' xterm-256
+[[ ${reply[*]} == '18 52 86' ]]
+
+normalize_theme_value() {
+  emulate -L zsh
+  local value=$1 token result= is_background
+
+  for token in ${(s:,:)value}; do
+    if [[ $token == (none|(no-|)(bold|blink|conceal|reverse|standout|underline)) ]]; then
+      result+="${result:+,}$token"
+      continue
+    fi
+    is_background=0
+    if [[ $token == bg:* ]]; then
+      is_background=1
+      token=${token#bg:}
+    fi
+    result+=${result:+,}
+    (( is_background )) && result+='bg=' || result+='fg='
+    result+=$token
+  done
+  REPLY=$result
+}
+
+typeset style candidate inikey expected
+typeset -a candidates
+_fsh_validate_theme "$plugin_root/themes/default.ini" "$plugin_root/themes" shipped
+for style in "${_fsh_theme_style_order[@]}"; do
+  if [[ $style == secondary ]]; then
+    inikey=${_fsh_validated_theme_data[(i)<*>_secondary]}
+    expected=${_fsh_validated_theme_data[$inikey]}
+  else
+    candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
+    inikey=
+    for candidate in "${candidates[@]}"; do
+      [[ $candidate == - ]] && candidate=$style
+      inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
+      [[ -n $inikey ]] && break
+    done
+    normalize_theme_value "${_fsh_validated_theme_data[$inikey]}"
+    expected=$REPLY
+  fi
+  [[ ${_fsh_styles[$style]-} == "$expected" ]] || {
+    builtin print -u2 -r -- \
+      "f-sy-h: built-in default style drifted: $style (${_fsh_styles[$style]-} != $expected)"
+    exit 1
+  }
+done
+
+typeset -A persisted_free
+_fsh_read_ini "$plugin_root/share/free_theme.ini" persisted_free ''
+_fsh_validate_theme "$plugin_root/themes/free.ini" "$plugin_root/themes" shipped
+for style in "${_fsh_theme_style_order[@]}"; do
+  if [[ $style == secondary ]]; then
+    inikey=${_fsh_validated_theme_data[(i)<*>_secondary]}
+    expected=${_fsh_validated_theme_data[$inikey]}
+  else
+    candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
+    inikey=
+    for candidate in "${candidates[@]}"; do
+      [[ $candidate == - ]] && candidate=$style
+      inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
+      [[ -n $inikey ]] && break
+    done
+    normalize_theme_value "${_fsh_validated_theme_data[$inikey]}"
+    expected=$REPLY
+  fi
+  [[ ${persisted_free[<styles>_free${style}]-} == "$expected" ]] || {
+    builtin print -u2 -r -- \
+      "f-sy-h: packaged free style drifted: $style (${persisted_free[<styles>_free${style}]-} != $expected)"
+    exit 1
+  }
+done
+
 fsh_theme --quiet "$fixture_root/sample-overlay.ini"
 [[ -s $fixture_root/work/theme_overlay.ini ]]
 if fsh_theme --quiet "$fixture_root/invalid-values.ini" 2>"$fixture_root/theme-error"; then

--- a/themes/base16.ini
+++ b/themes/base16.ini
@@ -1,3 +1,8 @@
+[theme]
+palette = terminal-ansi16
+foreground = default
+background = default
+
 [base]
 default          = none
 unknown-token    = 1,bold

--- a/themes/clean.ini
+++ b/themes/clean.ini
@@ -1,6 +1,11 @@
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 124,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = yellow
@@ -62,13 +67,13 @@ back-or-dollar-double-quoted-argument = 185
 variable             = none
 assign               = none
 assign-array-bracket = 109
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
+mathvar = 69,bold
 mathnum = 208
 optarg-number = 208
-matherr = 124
+matherr = 210
 
 [for-loop]
 forvar = none

--- a/themes/default.ini
+++ b/themes/default.ini
@@ -1,17 +1,22 @@
 ; default theme, also embedded in the source of fast-syntax-highlighting
 
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = red,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = yellow
-here-string-text = 18
+here-string-text = 69
 here-string-var  = cyan,bg:18
 exec-descriptor  = yellow,bold
 comment          = 243
-correct-subtle   = 12
-incorrect-subtle = red
+correct-subtle   = 69
+incorrect-subtle = 210
 subtle-separator = green
 subtle-bg        = bg:18
 secondary        = free
@@ -33,10 +38,10 @@ double-sq-bracket = green
 double-paren   = yellow
 
 [paths]
-path          = magenta
+path          = 13
 pathseparator =
-path-to-dir   = magenta,underline
-globbing      = blue,bold
+path-to-dir   = 13,underline
+globbing      = 69,bold
 globbing-ext  = 13
 
 [brackets]
@@ -64,17 +69,17 @@ back-or-dollar-double-quoted-argument = cyan
 variable             = 113
 assign               = none
 assign-array-bracket = green
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
-mathnum = magenta
-optarg-number = magenta
-matherr = red
+mathvar = 69,bold
+mathnum = 13
+optarg-number = 13
+matherr = 210
 
 [for-loop]
 forvar = none
-fornum = magenta
+fornum = 13
 ; operator
 foroper = yellow
 ; separator

--- a/themes/forest.ini
+++ b/themes/forest.ini
@@ -1,6 +1,11 @@
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 124,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = yellow
@@ -68,7 +73,7 @@ history-expansion    = 114
 mathvar = 114
 mathnum = 107
 optarg-number = 107
-matherr = 124
+matherr = 210
 
 [for-loop]
 forvar = none

--- a/themes/free.ini
+++ b/themes/free.ini
@@ -1,6 +1,11 @@
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = red,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = yellow
@@ -39,7 +44,7 @@ globbing-ext  = 118
 
 [brackets]
 paired-bracket = bg:blue
-bracket-level-1 = 130
+bracket-level-1 = 136
 bracket-level-2 = 70
 bracket-level-3 = 69
 
@@ -62,13 +67,13 @@ back-or-dollar-double-quoted-argument = 110
 variable             = none
 assign               = none
 assign-array-bracket = 180
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
+mathvar = 69,bold
 mathnum = 166
 optarg-number = 166
-matherr = red
+matherr = 210
 
 [for-loop]
 forvar = none

--- a/themes/q-jmnemonic.ini
+++ b/themes/q-jmnemonic.ini
@@ -41,9 +41,14 @@
 ; Token.Operator: "#677dcf" -> CIELab: 68 (SteelBlue3; naive: 68)
 ;
 
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default           = none
-unknown-token     = 196
+unknown-token     = 210
 secondary         = sv-orple
 recursive-base    = 183
 
@@ -150,7 +155,7 @@ bracket-level-3 = 220
 mathvar = 68
 mathnum = 173
 optarg-number = 173
-matherr = 124
+matherr = 210
 
 [for-loop]
 forvar = 68

--- a/themes/safari.ini
+++ b/themes/safari.ini
@@ -1,8 +1,13 @@
 ; Light theme with colors of a Sahara oasis
 
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = red,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = yellow
@@ -64,13 +69,13 @@ back-or-dollar-double-quoted-argument = 153
 variable             = none
 assign               = none
 assign-array-bracket = 185
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
+mathvar = 69,bold
 mathnum = 187
 optarg-number = 187
-matherr = red
+matherr = 210
 
 [for-loop]
 forvar = none

--- a/themes/spa.ini
+++ b/themes/spa.ini
@@ -1,7 +1,12 @@
 ; 144, 187, 110, 203
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 196
+unknown-token    = 210
 commandseparator = 150
 redirection      = none
 here-string-tri  = yellow
@@ -63,13 +68,13 @@ back-or-dollar-double-quoted-argument = 186
 variable             = none
 assign               = none
 assign-array-bracket = 187
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
 mathvar = 150
 mathnum = 110
 optarg-number = 110
-matherr = 196
+matherr = 210
 
 [for-loop]
 forvar = 71

--- a/themes/sv-orple.ini
+++ b/themes/sv-orple.ini
@@ -17,16 +17,21 @@
 ; formula-bg:
 ;   #211f37 -> 16 (17)
 
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 124
+unknown-token    = 210
 commandseparator = 146
 redirection      = none
 here-string-tri  = 138
 here-string-text = bg:25
-here-string-var  = 140,bg:25
+here-string-var  = 225,bg:25
 exec-descriptor  = 140
-comment          = 61
+comment          = 103
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
 subtle-separator = 146
@@ -81,13 +86,13 @@ back-or-dollar-double-quoted-argument = 140
 variable             = none
 assign               = none
 assign-array-bracket = 182
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
 mathvar = 140
 mathnum = 173
 optarg-number = 173
-matherr = 124
+matherr = 210
 
 [for-loop]
 forvar = 140
@@ -99,5 +104,5 @@ forsep = 182
 
 [case]
 case-input       = 140
-case-parentheses = 17
+case-parentheses = 68
 case-condition   = bg:25

--- a/themes/sv-plant.ini
+++ b/themes/sv-plant.ini
@@ -17,16 +17,21 @@
 ; formula:
 ;   #3f352a -> 16
 
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 124
+unknown-token    = 210
 commandseparator = 189
 redirection      = none
 here-string-tri  = 157
 here-string-text = bg:25
-here-string-var  = 180,bg:25
+here-string-var  = 224,bg:25
 exec-descriptor  = 180
-comment          = 58
+comment          = 101
 correct-subtle   = bg:55
 incorrect-subtle = bg:52
 subtle-separator = 189
@@ -81,13 +86,13 @@ back-or-dollar-double-quoted-argument = 180
 variable             = none
 assign               = none
 assign-array-bracket = 224
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
 mathvar = 180
 mathnum = 114
 optarg-number = 114
-matherr = 124
+matherr = 210
 
 [for-loop]
 forvar = 180
@@ -99,5 +104,5 @@ forsep = 224
 
 [case]
 case-input       = 180
-case-parentheses = 58
+case-parentheses = 101
 case-condition   = bg:25

--- a/themes/z-shell.ini
+++ b/themes/z-shell.ini
@@ -1,6 +1,11 @@
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = 196,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = 141
@@ -18,16 +23,16 @@ recursive-base   = 190
 [command-point]
 reserved-word  = 48
 subcommand     = 51
-alias          = 93
-suffix-alias   = 93
+alias          = 135
+suffix-alias   = 135
 global-alias   = bg:19
-builtin        = 93
-function       = 93
-command        = 93
-precommand     = 93
-hashed-command = 93
-single-sq-bracket = 93
-double-sq-bracket = 93
+builtin        = 135
+function       = 135
+command        = 135
+precommand     = 135
+hashed-command = 135
+single-sq-bracket = 135
+double-sq-bracket = 135
 double-paren   = 48
 
 [paths]
@@ -61,14 +66,14 @@ back-or-dollar-double-quoted-argument = 45
 [other]
 variable             = none
 assign               = none
-assign-array-bracket = 93
-history-expansion    = blue,bold
+assign-array-bracket = 135
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
+mathvar = 69,bold
 mathnum = 82
 optarg-number = 82
-matherr = red
+matherr = 210
 
 [for-loop]
 forvar = none
@@ -79,6 +84,6 @@ foroper = 48
 forsep = 111
 
 [case]
-case-input       = 93
+case-input       = 135
 case-parentheses = 141
 case-condition   = bg:19

--- a/themes/zdharma.ini
+++ b/themes/zdharma.ini
@@ -1,6 +1,11 @@
+[theme]
+palette = xterm-256
+foreground = #ffffff
+background = #000000
+
 [base]
 default          = none
-unknown-token    = red,bold
+unknown-token    = 210,bold
 commandseparator = none
 redirection      = none
 here-string-tri  = 141
@@ -41,7 +46,7 @@ globbing-ext  = 153
 paired-bracket = bg:blue
 bracket-level-1 = 117
 bracket-level-2 = 141
-bracket-level-3 = 90
+bracket-level-3 = 170
 
 [arguments]
 single-hyphen-option   = 177
@@ -62,13 +67,13 @@ back-or-dollar-double-quoted-argument = 177
 variable             = none
 assign               = none
 assign-array-bracket = 63
-history-expansion    = blue,bold
+history-expansion    = 69,bold
 
 [math]
-mathvar = blue,bold
+mathvar = 69,bold
 mathnum = 154
 optarg-number = 154
-matherr = red
+matherr = 210
 
 [for-loop]
 forvar = none

--- a/tools/validate-themes.zsh
+++ b/tools/validate-themes.zsh
@@ -6,7 +6,8 @@ setopt no_unset no_function_argzero posix_argzero
 typeset -r plugin_root=${${(%):-%N}:A:h:h}
 fpath=( "$plugin_root/functions" $fpath )
 source "$plugin_root/lib/theme-schema.zsh"
-autoload -Uz _fsh_read_ini _fsh_validate_theme
+autoload -Uz _fsh_read_ini _fsh_theme_color_rgb _fsh_validate_theme_contrast \
+  _fsh_validate_theme
 
 json_escape() {
   emulate -L zsh
@@ -21,12 +22,14 @@ json_escape() {
 typeset -a theme_paths=( "$@" )
 (( $#theme_paths )) || theme_paths=( "$plugin_root"/themes/*.ini(N) )
 
-typeset theme_path path_json diagnostic code message code_json message_json
+typeset theme_path path_json diagnostic code message code_json message_json validation_mode
 integer exit_status=0
 for theme_path in "${theme_paths[@]}"; do
   json_escape "${theme_path:A}"
   path_json=$REPLY
-  if _fsh_validate_theme "$theme_path" "$plugin_root/themes"; then
+  validation_mode=
+  [[ ${theme_path:A:h} == ${plugin_root:A}/themes ]] && validation_mode=shipped
+  if _fsh_validate_theme "$theme_path" "$plugin_root/themes" "$validation_mode"; then
     builtin printf \
       '{"schema":"fsh-theme-validation/v1","path":"%s","status":"ok","code":"ok","message":"","declaredStyles":%d,"resolvedStyles":%d}\n' \
       "$path_json" $_fsh_theme_declared_count $_fsh_theme_resolved_count


### PR DESCRIPTION
# Pull request

## Summary

- establish 4.5:1 ordinary and 7:1 critical contrast floors for shipped themes
- add exact xterm-256 rendering metadata and adaptive ANSI-16 validation for base16
- remediate shipped palettes and keep built-in and packaged theme data synchronized
- preserve external themes without metadata and skip standalone contrast checks for overlays

Closes #84

Part of #79

## Verification

- all 12 shipped themes pass `zsh -f tools/validate-themes.zsh`
- all 15 integration checks pass on Zsh 5.9.2
- ZUnit 0.8.2: 21 passed, 0 failed, using a binary unchanged from CI pin `15061c83373be80b523988121b7ba12c6b2d82dc`
- native syntax and `zcompile` checks pass for 65 files
- `git diff --check` passes
- direct gitleaks scan reports no leaks
- pre-commit checks report no issues across all 22 changed files

## Compatibility and lifecycle

The public entrypoint and public function surface are unchanged. Metadata is
required only for shipped themes; external themes without metadata retain the
existing validation behavior. New private autoload functions are owned and
restored by the existing lifecycle machinery, including after lazy theme
validation. Base16 remains terminal-adaptive and is restricted to ANSI colors
0 through 15 rather than assigned a fixed contrast claim.

Local lifecycle and integration coverage passed on Zsh 5.9.2. The existing CI
matrix remains responsible for the Zsh 5.8 compatibility run.

## Agent handoff

No handoff needed.
