### PR TITLE
fix(themes): distinguish opposed semantic styles

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -406,7 +406,8 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 builtin autoload -Uz -- is-at-least \
-  _fsh_read_ini _fsh_theme_color_rgb _fsh_validate_theme_contrast \
+  _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_resolve_rendering \
+  _fsh_validate_theme_contrast _fsh_validate_theme_distinguishability \
   _fsh_validate_theme _fsh_run_git_command \
   _fsh_make_targets _fsh_run_command _fsh_read_all \
   _fsh_async_command _fsh_async_command_callback

--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ ANSI indices 0 through 15 instead of claiming a fixed contrast ratio. Metadata
 remains optional for external themes, preserving existing user themes; when it
 is present, the same validation contract applies.
 
+That contract also keeps semantically opposed styles distinguishable. The
+validator compares resolved rendering state rather than raw INI text, so named
+and indexed equivalents, backgrounds, attributes, `none`, and `reverse` are
+canonicalized before comparison. Single- and double-hyphen options, string and
+numeric option arguments, and subcommands and string option arguments must
+differ. Command and builtin styles, function and command styles, and alias and
+suffix-alias styles may intentionally share a rendering. Overlays are checked
+as partial customizations, so standalone overlay validation does not enforce
+these pair relationships against an unknown base theme.
+
 The ZUnit command requires the repository's pinned ZUnit toolchain.
 
 ## Documentation and support

--- a/functions/_fsh_theme_resolve_rendering
+++ b/functions/_fsh_theme_resolve_rendering
@@ -1,0 +1,92 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Resolve one style to a palette-canonical effective rendering.
+#
+# $1 - canonical style name
+# $2 - palette name
+# $3 - declared default foreground
+# $4 - declared default background
+#
+# Results:
+# - reply: foreground, background, bold, blink, conceal, standout, underline
+# - REPLY: stable labelled signature of the same rendering
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local style=$1 palette=$2 default_foreground=$3 default_background=$4
+local candidate inikey value token foreground=$default_foreground background=$default_background
+local temporary color_role color_value normalized_color
+local -A attributes=( bold 0 blink 0 conceal 0 standout 0 underline 0 )
+local -A ansi_names=(
+  black 0 red 1 green 2 yellow 3 blue 4 magenta 5 cyan 6 white 7
+)
+local -a candidates color_rgb
+integer reverse=0
+
+reply=()
+REPLY=
+candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
+for candidate in "${candidates[@]}"; do
+  [[ $candidate == - ]] && candidate=$style
+  inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
+  [[ -n $inikey ]] && break
+done
+[[ -n $inikey ]] || return 1
+
+value=${_fsh_validated_theme_data[$inikey]}
+for token in ${(s:,:)value}; do
+  case $token in
+    (none)
+      foreground=$default_foreground
+      background=$default_background
+      reverse=0
+      attributes=( bold 0 blink 0 conceal 0 standout 0 underline 0 )
+      ;;
+    (reverse) reverse=1 ;;
+    (no-reverse) reverse=0 ;;
+    (bold|blink|conceal|standout|underline) attributes[$token]=1 ;;
+    (no-(bold|blink|conceal|standout|underline)) attributes[${token#no-}]=0 ;;
+    (bg:*) background=${token#bg:} ;;
+    (*) foreground=$token ;;
+  esac
+done
+
+if (( reverse )); then
+  temporary=$foreground
+  foreground=$background
+  background=$temporary
+fi
+[[ $foreground == default ]] && foreground=$default_foreground
+[[ $background == default ]] && background=$default_background
+
+for color_role in foreground background; do
+  [[ $color_role == foreground ]] && color_value=$foreground || color_value=$background
+  if [[ $palette == xterm-256 ]]; then
+    _fsh_theme_color_rgb "$color_value" "$palette" || return 1
+    color_rgb=( "${reply[@]}" )
+    builtin printf -v normalized_color '#%02x%02x%02x' \
+      ${color_rgb[1]} ${color_rgb[2]} ${color_rgb[3]}
+  elif [[ $palette == terminal-ansi16 ]]; then
+    if [[ $color_value == default ]]; then
+      normalized_color=default
+    elif (( ${+ansi_names[$color_value]} )); then
+      normalized_color="ansi:${ansi_names[$color_value]}"
+    elif [[ $color_value == (0|[1-9][0-9]#) ]] && (( color_value <= 15 )); then
+      normalized_color="ansi:$color_value"
+    else
+      return 1
+    fi
+  else
+    return 1
+  fi
+  [[ $color_role == foreground ]] && foreground=$normalized_color || background=$normalized_color
+done
+
+reply=(
+  "$foreground" "$background"
+  ${attributes[bold]} ${attributes[blink]} ${attributes[conceal]}
+  ${attributes[standout]} ${attributes[underline]}
+)
+REPLY="fg=$foreground,bg=$background,bold=${attributes[bold]},blink=${attributes[blink]},conceal=${attributes[conceal]},standout=${attributes[standout]},underline=${attributes[underline]}"

--- a/functions/_fsh_validate_theme
+++ b/functions/_fsh_validate_theme
@@ -148,6 +148,7 @@ if (( $#metadata_seen == $#metadata_keys )); then
     if [[ $style_mode == full && $foreground == \#[0-9a-fA-F](#c6,6) &&
       $background == \#[0-9a-fA-F](#c6,6) ]]; then
       _fsh_validate_theme_contrast "$palette" "$foreground" "$background"
+      _fsh_validate_theme_distinguishability "$palette" "$foreground" "$background"
     fi
   elif [[ $palette == terminal-ansi16 ]]; then
     [[ $foreground == default && $background == default ]] ||
@@ -170,6 +171,7 @@ if (( $#metadata_seen == $#metadata_keys )); then
             "adaptive-palette-out-of-range|$declared_key uses color outside terminal ANSI 0-15: $token" )
         done
       done
+      _fsh_validate_theme_distinguishability "$palette" "$foreground" "$background"
     fi
   fi
 fi

--- a/functions/_fsh_validate_theme_contrast
+++ b/functions/_fsh_validate_theme_contrast
@@ -11,48 +11,18 @@ builtin emulate -L zsh
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 local palette=$1 default_foreground=$2 default_background=$3
-local style candidate inikey value token foreground background minimum contrast_text
-local -a candidates reply foreground_rgb background_rgb
-integer reverse component
+local style candidate foreground background minimum contrast_text REPLY
+local -a reply foreground_rgb background_rgb
+integer component
 float foreground_luminance background_luminance lighter darker contrast channel linear
 
 for style in "${_fsh_theme_style_order[@]}"; do
   [[ $style == secondary ]] && continue
 
-  candidates=( ${(s. .)_fsh_theme_style_fallbacks[$style]} default )
-  inikey=
-  for candidate in "${candidates[@]}"; do
-    [[ $candidate == - ]] && candidate=$style
-    inikey=${_fsh_validated_theme_data[(i)<*>_${candidate}]}
-    [[ -n $inikey ]] && break
-  done
-  [[ -n $inikey ]] || continue
-
-  value=${_fsh_validated_theme_data[$inikey]}
-  foreground=$default_foreground
-  background=$default_background
-  reverse=0
-  for token in ${(s:,:)value}; do
-    case $token in
-      (none)
-        foreground=$default_foreground
-        background=$default_background
-        reverse=0
-        ;;
-      (reverse) reverse=1 ;;
-      (no-reverse) reverse=0 ;;
-      (bg:*) background=${token#bg:} ;;
-      ((no-|)(bold|blink|conceal|standout|underline)) ;;
-      (*) foreground=$token ;;
-    esac
-  done
-  if (( reverse )); then
-    candidate=$foreground
-    foreground=$background
-    background=$candidate
-  fi
-  [[ $foreground == default ]] && foreground=$default_foreground
-  [[ $background == default ]] && background=$default_background
+  _fsh_theme_resolve_rendering \
+    "$style" "$palette" "$default_foreground" "$default_background" || continue
+  foreground=$reply[1]
+  background=$reply[2]
 
   _fsh_theme_color_rgb "$foreground" "$palette" || continue
   foreground_rgb=( "${reply[@]}" )

--- a/functions/_fsh_validate_theme_distinguishability
+++ b/functions/_fsh_validate_theme_distinguishability
@@ -1,0 +1,35 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Enforce semantic pair policy against fully resolved theme rendering state.
+#
+# $1 - palette name
+# $2 - declared default foreground
+# $3 - declared default background
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local palette=$1 default_foreground=$2 default_background=$3
+local pair policy left_style right_style left_signature right_signature REPLY
+local -a fields reply
+
+for pair in "${_fsh_theme_semantic_pair_policy[@]}"; do
+  fields=( ${(s: :)pair} )
+  policy=$fields[1]
+  left_style=$fields[2]
+  right_style=$fields[3]
+  [[ $policy == require-distinct ]] || continue
+
+  _fsh_theme_resolve_rendering \
+    "$left_style" "$palette" "$default_foreground" "$default_background" || continue
+  left_signature=$REPLY
+  _fsh_theme_resolve_rendering \
+    "$right_style" "$palette" "$default_foreground" "$default_background" || continue
+  right_signature=$REPLY
+
+  [[ $left_signature != "$right_signature" ]] ||
+    _fsh_theme_validation_errors+=(
+      "indistinguishable-styles|$left_style and $right_style resolve to the same rendering ($left_signature)"
+    )
+done

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -58,7 +58,7 @@ typeset -gA _fsh_styles
 : ${_fsh_styles[default]:=none}
 : ${_fsh_styles[unknown-token]:=fg=210,bold}
 : ${_fsh_styles[reserved-word]:=fg=yellow}
-: ${_fsh_styles[subcommand]:=fg=yellow}
+: ${_fsh_styles[subcommand]:=fg=yellow,bold}
 : ${_fsh_styles[alias]:=fg=green}
 : ${_fsh_styles[suffix-alias]:=fg=green}
 : ${_fsh_styles[global-alias]:=bg=blue}
@@ -75,7 +75,7 @@ typeset -gA _fsh_styles
 : ${_fsh_styles[globbing-ext]:=fg=13}
 : ${_fsh_styles[history-expansion]:=fg=69,bold}
 : ${_fsh_styles[single-hyphen-option]:=fg=cyan}
-: ${_fsh_styles[double-hyphen-option]:=fg=cyan}
+: ${_fsh_styles[double-hyphen-option]:=fg=cyan,bold}
 : ${_fsh_styles[back-quoted-argument]:=none}
 : ${_fsh_styles[single-quoted-argument]:=fg=yellow}
 : ${_fsh_styles[double-quoted-argument]:=fg=yellow}

--- a/lib/theme-schema.zsh
+++ b/lib/theme-schema.zsh
@@ -91,3 +91,15 @@ typeset -gA _fsh_theme_critical_styles=(
   incorrect-subtle  1
   matherr           1
 )
+
+# Semantic pairs are ordered for deterministic validator diagnostics. Distinct
+# pairs must not resolve to the same effective rendering. Shared pairs document
+# intentional command-family and alias-family grouping.
+typeset -ga _fsh_theme_semantic_pair_policy=(
+  'require-distinct single-hyphen-option double-hyphen-option'
+  'require-distinct optarg-string optarg-number'
+  'require-distinct subcommand optarg-string'
+  'allow-shared command builtin'
+  'allow-shared alias suffix-alias'
+  'allow-shared function command'
+)

--- a/share/free_theme.ini
+++ b/share/free_theme.ini
@@ -20,7 +20,7 @@ freecomment=fg=243
 freecorrect-subtle=bg=55
 freedefault=none
 freedollar-quoted-argument=fg=150
-freedouble-hyphen-option=fg=110
+freedouble-hyphen-option=fg=110,bold
 freedouble-paren=fg=150
 freedouble-quoted-argument=fg=150
 freedouble-sq-bracket=fg=180
@@ -56,7 +56,7 @@ freesecondary=zdharma
 freesingle-hyphen-option=fg=110
 freesingle-quoted-argument=fg=150
 freesingle-sq-bracket=fg=180
-freesubcommand=fg=150
+freesubcommand=fg=150,bold
 freesubtle-bg=bg=18
 freesubtle-separator=none
 freesuffix-alias=fg=180

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -14,6 +14,64 @@ output=$(zsh -f "$plugin_root/tools/validate-themes.zsh")
 [[ $output == *'"schema":"fsh-theme-validation/v1"'* ]]
 [[ $output == *'"declaredStyles":61,"resolvedStyles":60'* ]]
 
+command sed 's/^double-hyphen-option   = 143$/double-hyphen-option   = 104/' \
+  "$plugin_root/themes/q-jmnemonic.ini" >| "$fixture_root/semantic-collision.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/semantic-collision.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: identical semantic styles unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"indistinguishable-styles"'* ]]
+[[ $output == *'single-hyphen-option and double-hyphen-option resolve to the same rendering'* ]]
+
+command sed 's/^double-hyphen-option   = cyan,bold$/double-hyphen-option   = 6/' \
+  "$plugin_root/themes/default.ini" >| "$fixture_root/canonical-color-collision.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/canonical-color-collision.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: equivalent named and indexed colours unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"indistinguishable-styles"'* ]]
+
+command sed \
+  -e 's/^single-hyphen-option         = 104$/single-hyphen-option         = none/' \
+  -e 's/^double-hyphen-option   = 143$/double-hyphen-option   = default/' \
+  "$plugin_root/themes/q-jmnemonic.ini" >| "$fixture_root/default-color-collision.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/default-color-collision.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: equivalent default renderings unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"indistinguishable-styles"'* ]]
+
+command sed \
+  -e 's/^single-hyphen-option         = 104$/single-hyphen-option         = black,bg:104,reverse/' \
+  -e 's/^double-hyphen-option   = 143$/double-hyphen-option   = 104/' \
+  "$plugin_root/themes/q-jmnemonic.ini" >| "$fixture_root/reverse-collision.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/reverse-collision.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: reverse-equivalent semantic styles unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"indistinguishable-styles"'* ]]
+
+command sed 's/^double-hyphen-option   = 3,bold$/double-hyphen-option   = yellow/' \
+  "$plugin_root/themes/base16.ini" >| "$fixture_root/adaptive-collision.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/adaptive-collision.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: equivalent adaptive ANSI colours unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"indistinguishable-styles"'* ]]
+
+command sed \
+  -e '/^\[theme\]$/,/^$/d' \
+  -e 's/^double-hyphen-option   = cyan,bold$/double-hyphen-option   = 6/' \
+  "$plugin_root/themes/default.ini" >| "$fixture_root/metadata-free-collision.ini"
+output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/metadata-free-collision.ini")
+[[ $output == *'"status":"ok"'* ]]
+
 command sed '1,5d' "$plugin_root/themes/clean.ini" >| "$fixture_root/custom-no-metadata.ini"
 output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
   "$fixture_root/custom-no-metadata.ini")
@@ -117,10 +175,12 @@ output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
   builtin print -r -- 'background=#000000'
   builtin print -r -- '[base]'
   builtin print -r -- 'comment=#000000'
+  builtin print -r -- 'single-hyphen-option=104'
+  builtin print -r -- 'double-hyphen-option=104'
 } >| "$fixture_root/metadata-overlay.ini"
 output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
   "$fixture_root/metadata-overlay.ini")
-[[ $output == *'"status":"ok"'*'"declaredStyles":1,"resolvedStyles":0'* ]]
+[[ $output == *'"status":"ok"'*'"declaredStyles":3,"resolvedStyles":0'* ]]
 
 typeset -gx ZDOTDIR=$fixture_root/zdotdir
 typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home

--- a/themes/base16.ini
+++ b/themes/base16.ini
@@ -50,7 +50,7 @@ bracket-level-3 = 2,bold
 
 [arguments]
 single-hyphen-option   = 3
-double-hyphen-option   = 3
+double-hyphen-option   = 3,bold
 back-quoted-argument   = none
 single-quoted-argument = 2
 double-quoted-argument = 2

--- a/themes/clean.ini
+++ b/themes/clean.ini
@@ -50,7 +50,7 @@ bracket-level-3 = 220
 
 [arguments]
 single-hyphen-option   = 185
-double-hyphen-option   = 185
+double-hyphen-option   = 185,bold
 back-quoted-argument   = none
 single-quoted-argument = 147
 double-quoted-argument = 147

--- a/themes/default.ini
+++ b/themes/default.ini
@@ -24,7 +24,7 @@ recursive-base     = none
 
 [command-point]
 reserved-word  = yellow
-subcommand     = yellow
+subcommand     = yellow,bold
 alias          = green
 suffix-alias   = green
 global-alias   = bg:blue
@@ -52,7 +52,7 @@ bracket-level-3 = cyan,bold
 
 [arguments]
 single-hyphen-option   = cyan
-double-hyphen-option   = cyan
+double-hyphen-option   = cyan,bold
 back-quoted-argument   = none
 single-quoted-argument = yellow
 double-quoted-argument = yellow

--- a/themes/forest.ini
+++ b/themes/forest.ini
@@ -22,7 +22,7 @@ recursive-base   = 183
 
 [command-point]
 reserved-word  = 186
-subcommand     = 186
+subcommand     = 186,bold
 alias          = 101
 suffix-alias   = 101
 global-alias   = bg:55
@@ -50,7 +50,7 @@ bracket-level-3 = cyan,bold
 
 [arguments]
 single-hyphen-option   = 65
-double-hyphen-option   = 65
+double-hyphen-option   = 65,bold
 back-quoted-argument   = none
 single-quoted-argument = 186
 double-quoted-argument = 186

--- a/themes/free.ini
+++ b/themes/free.ini
@@ -22,7 +22,7 @@ recursive-base   = 183
 
 [command-point]
 reserved-word  = 150
-subcommand     = 150
+subcommand     = 150,bold
 alias          = 180
 suffix-alias   = 180
 global-alias   = bg:19
@@ -50,7 +50,7 @@ bracket-level-3 = 69
 
 [arguments]
 single-hyphen-option   = 110
-double-hyphen-option   = 110
+double-hyphen-option   = 110,bold
 back-quoted-argument   = none
 single-quoted-argument = 150
 double-quoted-argument = 150

--- a/themes/q-jmnemonic.ini
+++ b/themes/q-jmnemonic.ini
@@ -154,7 +154,7 @@ bracket-level-3 = 220
 [math]
 mathvar = 68
 mathnum = 173
-optarg-number = 173
+optarg-number = 173,bold
 matherr = 210
 
 [for-loop]

--- a/themes/safari.ini
+++ b/themes/safari.ini
@@ -52,7 +52,7 @@ bracket-level-3 = 141
 
 [arguments]
 single-hyphen-option   = 152
-double-hyphen-option   = 152
+double-hyphen-option   = 152,bold
 back-quoted-argument   = none
 single-quoted-argument = 151
 double-quoted-argument = 151

--- a/themes/spa.ini
+++ b/themes/spa.ini
@@ -51,7 +51,7 @@ bracket-level-3 = 220
 
 [arguments]
 single-hyphen-option   = 185
-double-hyphen-option   = 185
+double-hyphen-option   = 185,bold
 back-quoted-argument   = none
 single-quoted-argument = 110
 double-quoted-argument = 110
@@ -73,7 +73,7 @@ history-expansion    = 69,bold
 [math]
 mathvar = 150
 mathnum = 110
-optarg-number = 110
+optarg-number = 110,bold
 matherr = 210
 
 [for-loop]

--- a/themes/sv-orple.ini
+++ b/themes/sv-orple.ini
@@ -69,7 +69,7 @@ bracket-level-3 = 220
 
 [arguments]
 single-hyphen-option   = 140
-double-hyphen-option   = 140
+double-hyphen-option   = 140,bold
 back-quoted-argument   = none
 single-quoted-argument = 173
 double-quoted-argument = 173
@@ -91,7 +91,7 @@ history-expansion    = 69,bold
 [math]
 mathvar = 140
 mathnum = 173
-optarg-number = 173
+optarg-number = 173,bold
 matherr = 210
 
 [for-loop]

--- a/themes/sv-plant.ini
+++ b/themes/sv-plant.ini
@@ -69,7 +69,7 @@ bracket-level-3 = 220
 
 [arguments]
 single-hyphen-option   = 180
-double-hyphen-option   = 180
+double-hyphen-option   = 180,bold
 back-quoted-argument   = none
 single-quoted-argument = 114
 double-quoted-argument = 114
@@ -91,7 +91,7 @@ history-expansion    = 69,bold
 [math]
 mathvar = 180
 mathnum = 114
-optarg-number = 114
+optarg-number = 114,bold
 matherr = 210
 
 [for-loop]

--- a/themes/z-shell.ini
+++ b/themes/z-shell.ini
@@ -50,7 +50,7 @@ bracket-level-3 = 50
 
 [arguments]
 single-hyphen-option   = 45
-double-hyphen-option   = 45
+double-hyphen-option   = 45,bold
 back-quoted-argument   = none
 single-quoted-argument = 48
 double-quoted-argument = 48

--- a/themes/zdharma.ini
+++ b/themes/zdharma.ini
@@ -50,7 +50,7 @@ bracket-level-3 = 170
 
 [arguments]
 single-hyphen-option   = 177
-double-hyphen-option   = 177
+double-hyphen-option   = 177,bold
 back-quoted-argument   = none
 single-quoted-argument = 146
 double-quoted-argument = 146

--- a/tools/validate-themes.zsh
+++ b/tools/validate-themes.zsh
@@ -6,7 +6,8 @@ setopt no_unset no_function_argzero posix_argzero
 typeset -r plugin_root=${${(%):-%N}:A:h:h}
 fpath=( "$plugin_root/functions" $fpath )
 source "$plugin_root/lib/theme-schema.zsh"
-autoload -Uz _fsh_read_ini _fsh_theme_color_rgb _fsh_validate_theme_contrast \
+autoload -Uz _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_resolve_rendering \
+  _fsh_validate_theme_contrast _fsh_validate_theme_distinguishability \
   _fsh_validate_theme
 
 json_escape() {


### PR DESCRIPTION
## Summary

- canonicalize effective theme renderings before semantic comparison
- enforce distinct option and argument categories while preserving documented sharing
- remediate 18 unintended collisions across the 12 shipped themes
- add focused regression coverage and document the validation contract

## Verification

- `zsh -f tools/validate-themes.zsh` (12 of 12 themes passed)
- `zsh -f tests/integration/test-theme-validator.zsh`
- complete repository integration matrix
- native syntax and `zcompile` checks across 67 files
- pinned ZUnit 0.8.2 suite: 21 passed, 0 failed
- `git diff --check`

## Supplemental tooling

Trunk bootstrap became nonresponsive in an isolated cache and was interrupted
after 120 seconds. Repository-native validation completed successfully.

Closes #85
