### PR TITLE
feat(themes): guard correctness colors under CVD

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -406,8 +406,9 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 builtin autoload -Uz -- is-at-least \
-  _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_resolve_rendering \
-  _fsh_validate_theme_contrast _fsh_validate_theme_distinguishability \
+  _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_color_cvd_lab \
+  _fsh_theme_resolve_rendering _fsh_validate_theme_contrast \
+  _fsh_validate_theme_cvd_separation _fsh_validate_theme_distinguishability \
   _fsh_validate_theme _fsh_run_git_command \
   _fsh_make_targets _fsh_run_command _fsh_read_all \
   _fsh_async_command _fsh_async_command_callback

--- a/README.md
+++ b/README.md
@@ -332,6 +332,18 @@ suffix-alias styles may intentionally share a rendering. Overlays are checked
 as partial customizations, so standalone overlay validation does not enforce
 these pair relationships against an unknown base theme.
 
+Fixed-palette themes also keep `correct-subtle` and `incorrect-subtle`
+separated under the published
+[Machado, Oliveira, and Fernandes](https://doi.org/10.1109/TVCG.2009.113)
+severity-1.0 protanopia, deuteranopia, and tritanopia simulation matrices. The
+validator converts each simulated foreground and background pair to
+[CIE 1976 L*a*b*](https://www.cie.co.at/publications/colorimetry-part-4-cie-1976-lab-colour-space-1)
+and requires at least one channel to retain a project-defined distance of
+20.0. Terminal-owned ANSI palettes and standalone overlays cannot make a fixed
+color claim, so this check does not apply to them. This regression guard is
+not a WCAG conformance claim or a substitute for a
+[non-color correctness cue](https://www.w3.org/TR/WCAG22/#use-of-color).
+
 The ZUnit command requires the repository's pinned ZUnit toolchain.
 
 ## Documentation and support

--- a/functions/_fsh_theme_color_cvd_lab
+++ b/functions/_fsh_theme_color_cvd_lab
@@ -1,0 +1,67 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Simulate one fixed sRGB color under a CVD model and convert it to CIELAB.
+#
+# $1 - exact #rrggbb color
+# $2 - model from _fsh_theme_cvd_models
+#
+# Result: reply=( L* a* b* )
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local color=$1 model=$2 hex
+local -a matrix source simulated linear xyz normalized transformed
+integer row offset
+float channel value
+
+reply=()
+[[ $color == \#[0-9a-fA-F](#c6,6) ]] || return 1
+(( ${+_fsh_theme_cvd_matrices[$model]} )) || return 1
+
+hex=${color#\#}
+source=(
+  $(( 16#${hex[1,2]} / 255.0 ))
+  $(( 16#${hex[3,4]} / 255.0 ))
+  $(( 16#${hex[5,6]} / 255.0 ))
+)
+matrix=( ${(s: :)_fsh_theme_cvd_matrices[$model]} )
+
+for row in 1 2 3; do
+  offset=$(( (row - 1) * 3 ))
+  (( value = matrix[offset + 1] * source[1] +
+    matrix[offset + 2] * source[2] + matrix[offset + 3] * source[3] ))
+  (( value < 0.0 )) && value=0.0
+  (( value > 1.0 )) && value=1.0
+  simulated+=( $value )
+done
+
+for channel in "${simulated[@]}"; do
+  if (( channel <= 0.04045 )); then
+    linear+=( $(( channel / 12.92 )) )
+  else
+    linear+=( $(( ((channel + 0.055) / 1.055) ** 2.4 )) )
+  fi
+done
+
+xyz=(
+  $(( 0.4124564 * linear[1] + 0.3575761 * linear[2] + 0.1804375 * linear[3] ))
+  $(( 0.2126729 * linear[1] + 0.7151522 * linear[2] + 0.0721750 * linear[3] ))
+  $(( 0.0193339 * linear[1] + 0.1191920 * linear[2] + 0.9503041 * linear[3] ))
+)
+normalized=( $(( xyz[1] / 0.95047 )) ${xyz[2]} $(( xyz[3] / 1.08883 )) )
+
+for value in "${normalized[@]}"; do
+  if (( value > 0.008856451679035631 )); then
+    transformed+=( $(( value ** (1.0 / 3.0) )) )
+  else
+    transformed+=( $(( 7.787037037037037 * value + 0.13793103448275862 )) )
+  fi
+done
+
+reply=(
+  $(( 116.0 * transformed[2] - 16.0 ))
+  $(( 500.0 * (transformed[1] - transformed[2]) ))
+  $(( 200.0 * (transformed[2] - transformed[3]) ))
+)

--- a/functions/_fsh_validate_theme
+++ b/functions/_fsh_validate_theme
@@ -149,6 +149,7 @@ if (( $#metadata_seen == $#metadata_keys )); then
       $background == \#[0-9a-fA-F](#c6,6) ]]; then
       _fsh_validate_theme_contrast "$palette" "$foreground" "$background"
       _fsh_validate_theme_distinguishability "$palette" "$foreground" "$background"
+      _fsh_validate_theme_cvd_separation "$palette" "$foreground" "$background"
     fi
   elif [[ $palette == terminal-ansi16 ]]; then
     [[ $foreground == default && $background == default ]] ||

--- a/functions/_fsh_validate_theme_cvd_separation
+++ b/functions/_fsh_validate_theme_cvd_separation
@@ -1,0 +1,59 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+#
+# Check correctness signaling under the declared fixed-palette CVD contract.
+#
+# $1 - palette name
+# $2 - declared default foreground
+# $3 - declared default background
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+local palette=$1 default_foreground=$2 default_background=$3 model separation_text REPLY
+local correct_foreground correct_background incorrect_foreground incorrect_background
+local -a reply correct_foreground_lab correct_background_lab
+local -a incorrect_foreground_lab incorrect_background_lab
+float foreground_separation background_separation separation
+
+[[ $palette == xterm-256 ]] || return 0
+
+_fsh_theme_resolve_rendering \
+  correct-subtle "$palette" "$default_foreground" "$default_background" || return 0
+correct_foreground=$reply[1]
+correct_background=$reply[2]
+_fsh_theme_resolve_rendering \
+  incorrect-subtle "$palette" "$default_foreground" "$default_background" || return 0
+incorrect_foreground=$reply[1]
+incorrect_background=$reply[2]
+
+for model in "${_fsh_theme_cvd_models[@]}"; do
+  _fsh_theme_color_cvd_lab "$correct_foreground" "$model" || continue
+  correct_foreground_lab=( "${reply[@]}" )
+  _fsh_theme_color_cvd_lab "$incorrect_foreground" "$model" || continue
+  incorrect_foreground_lab=( "${reply[@]}" )
+  _fsh_theme_color_cvd_lab "$correct_background" "$model" || continue
+  correct_background_lab=( "${reply[@]}" )
+  _fsh_theme_color_cvd_lab "$incorrect_background" "$model" || continue
+  incorrect_background_lab=( "${reply[@]}" )
+
+  (( foreground_separation = (
+    (correct_foreground_lab[1] - incorrect_foreground_lab[1]) ** 2.0 +
+    (correct_foreground_lab[2] - incorrect_foreground_lab[2]) ** 2.0 +
+    (correct_foreground_lab[3] - incorrect_foreground_lab[3]) ** 2.0
+  ) ** 0.5 ))
+  (( background_separation = (
+    (correct_background_lab[1] - incorrect_background_lab[1]) ** 2.0 +
+    (correct_background_lab[2] - incorrect_background_lab[2]) ** 2.0 +
+    (correct_background_lab[3] - incorrect_background_lab[3]) ** 2.0
+  ) ** 0.5 ))
+  (( foreground_separation >= background_separation )) &&
+    separation=$foreground_separation || separation=$background_separation
+
+  if (( separation < _fsh_theme_cvd_separation_floor )); then
+    builtin printf -v separation_text '%.2f' "$separation"
+    _fsh_theme_validation_errors+=(
+      "cvd-separation-too-low|correct-subtle and incorrect-subtle $model separation $separation_text is below $_fsh_theme_cvd_separation_floor"
+    )
+  fi
+done

--- a/lib/theme-schema.zsh
+++ b/lib/theme-schema.zsh
@@ -92,6 +92,18 @@ typeset -gA _fsh_theme_critical_styles=(
   matherr           1
 )
 
+# Fixed-palette correctness signals retain a project-defined CIELAB distance
+# under the published Machado, Oliveira, and Fernandes severity-1.0 models.
+# https://doi.org/10.1109/TVCG.2009.113
+# Matrix rows are kept as ordered strings because Zsh arrays cannot nest.
+typeset -g _fsh_theme_cvd_separation_floor=20.0
+typeset -ga _fsh_theme_cvd_models=( protanopia deuteranopia tritanopia )
+typeset -gA _fsh_theme_cvd_matrices=(
+  protanopia   '0.152286 1.052583 -0.204868 0.114503 0.786281 0.099216 -0.003882 -0.048116 1.051998'
+  deuteranopia '0.367322 0.860646 -0.227968 0.280085 0.672501 0.047413 -0.011820 0.042940 0.968881'
+  tritanopia   '1.255528 -0.076749 -0.178779 -0.078411 0.930809 0.147602 0.004733 0.691367 0.303900'
+)
+
 # Semantic pairs are ordered for deterministic validator diagnostics. Distinct
 # pairs must not resolve to the same effective rendering. Shared pairs document
 # intentional command-family and alias-family grouping.

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -24,6 +24,16 @@ fi
 [[ $output == *'"code":"indistinguishable-styles"'* ]]
 [[ $output == *'single-hyphen-option and double-hyphen-option resolve to the same rendering'* ]]
 
+command sed 's/^correct-subtle   = bg:55$/correct-subtle   = bg:0/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/cvd-separation-failure.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/cvd-separation-failure.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: CVD-confusable correctness styles unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"cvd-separation-too-low"'* ]]
+[[ $output == *'protanopia separation '*' is below 20.0'* ]]
+
 command sed 's/^double-hyphen-option   = cyan,bold$/double-hyphen-option   = 6/' \
   "$plugin_root/themes/default.ini" >| "$fixture_root/canonical-color-collision.ini"
 if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
@@ -203,6 +213,10 @@ _fsh_theme_color_rgb 196 xterm-256
 [[ ${reply[*]} == '255 0 0' ]]
 _fsh_theme_color_rgb '#123456' xterm-256
 [[ ${reply[*]} == '18 52 86' ]]
+_fsh_theme_color_cvd_lab '#5f0000' protanopia
+typeset cvd_lab_text
+builtin printf -v cvd_lab_text '%.2f %.2f %.2f' "${reply[1]}" "${reply[2]}" "${reply[3]}"
+[[ $cvd_lab_text == '3.01 -0.43 4.51' ]]
 
 normalize_theme_value() {
   emulate -L zsh

--- a/tools/validate-themes.zsh
+++ b/tools/validate-themes.zsh
@@ -6,8 +6,9 @@ setopt no_unset no_function_argzero posix_argzero
 typeset -r plugin_root=${${(%):-%N}:A:h:h}
 fpath=( "$plugin_root/functions" $fpath )
 source "$plugin_root/lib/theme-schema.zsh"
-autoload -Uz _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_resolve_rendering \
-  _fsh_validate_theme_contrast _fsh_validate_theme_distinguishability \
+autoload -Uz _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_color_cvd_lab \
+  _fsh_theme_resolve_rendering _fsh_validate_theme_contrast \
+  _fsh_validate_theme_cvd_separation _fsh_validate_theme_distinguishability \
   _fsh_validate_theme
 
 json_escape() {


### PR DESCRIPTION
# Pull request

## Summary

- validate fixed `xterm-256` correctness styles under the published Machado, Oliveira, and Fernandes severity-1.0 protanopia, deuteranopia, and tritanopia matrices
- compare resolved foreground and background pairs in CIE 1976 L*a*b* space and require at least one pair to retain the project-defined Delta E76 floor of 20.0
- add deterministic `cvd-separation-too-low` coverage and document that the guard is not WCAG conformance or a substitute for a non-color cue

Closes #86

## Verification

- Zsh 5.8: 69 native syntax and bytecode checks, plus all 15 integration checks
- Zsh 5.9.2: 69 native syntax and bytecode checks, plus all 15 integration checks
- pinned ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 21 passed, 0 failed
- shipped theme validation: 12 passed
- `git diff --check`

## Compatibility and lifecycle

The new criterion applies only to complete fixed `xterm-256` themes. Terminal-owned ANSI palettes and standalone overlays remain outside the fixed-color contract. There is no public entrypoint, plugin-manager, hook, widget, alias, parameter, module, `fpath`, or unload behavior change.

## Agent handoff

No handoff needed.
