### PR TITLE
feat(themes): ship a light-background theme

### DIFF
--- a/functions/fsh_theme
+++ b/functions/fsh_theme
@@ -148,9 +148,17 @@ fi
 
 if [[ -n "$OPT_LIST" ]]; then
   if [[ -z "$OPT_QUIET" ]]; then
+    local theme_path
+    local -A theme_metadata
     print -r -- "${fg_bold[yellow]}Available themes$reset_color:"
     print -r -- ""
-    print -rl -- "$_fsh_base_dir"/themes/*.ini(:t:r)
+    builtin printf '%-20s %s\n' 'Theme' 'Background'
+    for theme_path in "$_fsh_base_dir"/themes/*.ini(N); do
+      theme_metadata=()
+      _fsh_read_ini "$theme_path" theme_metadata '' || return 1
+      builtin printf '%-20s %s\n' \
+        "${theme_path:t:r}" "${theme_metadata[<theme>_background]:-unknown}"
+    done
     print -r -- ""
   fi
   return 0

--- a/tests/integration/test-theme-persistence.zsh
+++ b/tests/integration/test-theme-persistence.zsh
@@ -30,6 +30,16 @@ for theme_file in "$plugin_root"/themes/*.ini(N); do
   }
 done
 
+output=$(ZDOTDIR=$fixture_root/list-zdotdir XDG_CACHE_HOME=$fixture_root/list-cache \
+  zsh -f -c '
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    fsh_theme --list
+    fsh_plugin_unload
+  ' zsh "$fixture_root/list-work" "$plugin_root")
+[[ $output == *Theme*Background* ]]
+[[ $output == *light*'#ffffff'* ]]
+
 theme_work=$fixture_root/base16/work
 output=$(ZDOTDIR=$fixture_root/reload-zdotdir XDG_CACHE_HOME=$fixture_root/reload-cache \
   zsh -f -c '

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -9,7 +9,7 @@ trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
 
 typeset output
 output=$(zsh -f "$plugin_root/tools/validate-themes.zsh")
-(( ${#${(f)output}} == 12 ))
+(( ${#${(f)output}} == 13 ))
 [[ $output != *'"status":"error"'* ]]
 [[ $output == *'"schema":"fsh-theme-validation/v1"'* ]]
 [[ $output == *'"declaredStyles":61,"resolvedStyles":60'* ]]

--- a/themes/light.ini
+++ b/themes/light.ini
@@ -1,0 +1,89 @@
+[theme]
+palette = xterm-256
+foreground = #24292f
+background = #ffffff
+
+[base]
+default          = none
+unknown-token    = #82071e,bold
+commandseparator = none
+redirection      = none
+here-string-tri  = #0550ae
+here-string-text = bg:#ddf4ff
+here-string-var  = #0550ae,bg:#ddf4ff
+exec-descriptor  = #7d4e00,bold
+comment          = #57606a
+correct-subtle   = #ffffff,bg:#0550ae,bold
+incorrect-subtle = #ffffff,bg:#82071e,bold
+subtle-separator = none
+subtle-bg        = bg:#ddf4ff
+; secondary        =
+recursive-base   = #6639ba
+
+[command-point]
+reserved-word  = #6639ba
+subcommand     = #0550ae
+alias          = #0550ae
+suffix-alias   = #0550ae
+global-alias   = bg:#fff8c5
+builtin        = #0550ae
+function       = #0550ae
+command        = #0550ae
+precommand     = #6639ba
+hashed-command = #0550ae
+single-sq-bracket = #0550ae
+double-sq-bracket = #0550ae,bold
+double-paren   = #6639ba
+
+[paths]
+path          = #0550ae
+pathseparator =
+path-to-dir   = #0550ae,underline
+globbing      = #116329
+globbing-ext  = #7d4e00
+
+[brackets]
+paired-bracket = bg:#f6f8fa
+bracket-level-1 = #116329
+bracket-level-2 = #6639ba
+bracket-level-3 = #7d4e00
+
+[arguments]
+single-hyphen-option   = #116329
+double-hyphen-option   = #116329,bold
+back-quoted-argument   = none
+single-quoted-argument = #7d4e00
+double-quoted-argument = #6639ba
+optarg-string          = #6639ba,bold
+dollar-quoted-argument = #7d4e00
+
+[in-string]
+; backslash in $'...'
+back-dollar-quoted-argument           = #116329
+; backslash or $... in "..." (i.e. variable in string)
+back-or-dollar-double-quoted-argument = #0550ae
+
+[other]
+variable             = #82071e
+assign               = none
+assign-array-bracket = #6639ba
+history-expansion    = #82071e,bold
+
+[math]
+mathvar = #6639ba
+mathnum = #7d4e00
+optarg-number = #7d4e00
+matherr = #82071e,bold
+
+[for-loop]
+forvar = #6639ba
+fornum = #7d4e00
+; operator
+foroper = #6639ba,bold
+; separator
+forsep = #57606a
+
+[case]
+case-input       = #0550ae
+case-parentheses = #6639ba
+case-condition   = bg:#dafbe1


### PR DESCRIPTION
# Pull request

## Summary

- ship a validated `xterm-256` theme designed for a light background
- show each theme's declared background in `fsh_theme --list`
- cover the new theme count and list output in integration tests

Closes #87

## Verification

- `zsh -f tools/validate-themes.zsh`
- `zsh -f tests/integration/test-theme-validator.zsh`
- `zsh -f tests/integration/test-theme-persistence.zsh`
- full documented integration suite
- native Zsh syntax check across source, tests, completions, chroma, and tools
- ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 21 passed, 0 failed
- `git diff --check`

Local `trunk check --all` was unavailable because the configured cached
`gitleaks` binary was missing. It produced no source findings and did not
complete lint execution.

## Compatibility and lifecycle

`fsh_theme --list` gains a `Background` column. No entrypoint, supported Zsh,
plugin-manager, hook, widget, alias, parameter, module, `fpath`, or unload
behavior changes.

## Agent handoff

No handoff needed.
