### PR TITLE
perf: avoid lifecycle scans during highlighting

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -64,7 +64,7 @@ jobs:
           zsh -f tests/integration/test-git-runtime-knowledge.zsh
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
-          zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-highlight-performance.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
           zsh -f tests/integration/test-chroma-regions.zsh
@@ -75,6 +75,13 @@ jobs:
     name: Zsh 5.9.2
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      base_173_ms: ${{ steps.performance.outputs.base_173_ms }}
+      base_1000_ms: ${{ steps.performance.outputs.base_1000_ms }}
+      pr_173_ms: ${{ steps.performance.outputs.pr_173_ms }}
+      pr_1000_ms: ${{ steps.performance.outputs.pr_1000_ms }}
+      delta_173: ${{ steps.performance.outputs.delta_173 }}
+      delta_1000: ${{ steps.performance.outputs.delta_1000 }}
     steps:
       - name: Check out code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -129,12 +136,127 @@ jobs:
           zsh -f tests/integration/test-git-runtime-knowledge.zsh
           zsh -f tests/integration/test-passive-safety.zsh
           zsh -f tests/integration/test-hostile-autoloads.zsh
-          zsh -f tests/integration/test-highlight-budget.zsh
+          zsh -f tests/integration/test-highlight-performance.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
           zsh -f tests/integration/test-chroma-regions.zsh
           zsh -f tests/integration/test-async-chroma.zsh
           zsh -f tests/integration/test-theme-validator.zsh
+
+      - name: Compare highlighting performance
+        if: github.event_name == 'pull_request'
+        id: performance
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          base_dir="$RUNNER_TEMP/base"
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git worktree add --detach "$base_dir" "$BASE_SHA"
+
+          base_output=$(FSH_BENCHMARK_REPORT=1 \
+            zsh -f "$base_dir/tests/integration/test-highlight-budget.zsh") || true
+          pr_output=$(FSH_BENCHMARK_REPORT=1 \
+            zsh -f tests/integration/test-highlight-performance.zsh)
+
+          metric() {
+            awk -v target="$1" \
+              '$1 == "f-sy-h:" && $2 == target && $3 == "chars" {
+                sub(/^median=/, "", $4)
+                sub(/s$/, "", $4)
+                printf "%.3f", $4 * 1000
+              }'
+          }
+          difference() {
+            awk -v base="$1" -v pr="$2" \
+              'BEGIN { printf "%+.1f%%", ((pr - base) / base) * 100 }'
+          }
+
+          base_173=$(metric 173 <<<"$base_output")
+          base_1000=$(metric 1000 <<<"$base_output")
+          pr_173=$(metric 173 <<<"$pr_output")
+          pr_1000=$(metric 1000 <<<"$pr_output")
+          test -n "$base_173" && test -n "$base_1000"
+          test -n "$pr_173" && test -n "$pr_1000"
+
+          delta_173=$(difference "$base_173" "$pr_173")
+          delta_1000=$(difference "$base_1000" "$pr_1000")
+          {
+            echo "base_173_ms=$base_173"
+            echo "base_1000_ms=$base_1000"
+            echo "pr_173_ms=$pr_173"
+            echo "pr_1000_ms=$pr_1000"
+            echo "delta_173=$delta_173"
+            echo "delta_1000=$delta_1000"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo '### PR highlighting performance'
+            echo
+            echo '| Buffer | Base | PR | Difference |'
+            echo '| ---: | ---: | ---: | ---: |'
+            echo "| 173 chars | ${base_173} ms | ${pr_173} ms | ${delta_173} |"
+            echo "| 1000 chars | ${base_1000} ms | ${pr_1000} ms | ${delta_1000} |"
+            echo
+            echo 'Negative differences are faster. Medians use nine parses after one warm-up.'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  performance-comment:
+    name: PR Performance Comment
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: current
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update PR performance comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_173_MS: ${{ needs.current.outputs.base_173_ms }}
+          BASE_1000_MS: ${{ needs.current.outputs.base_1000_ms }}
+          PR_173_MS: ${{ needs.current.outputs.pr_173_ms }}
+          PR_1000_MS: ${{ needs.current.outputs.pr_1000_ms }}
+          DELTA_173: ${{ needs.current.outputs.delta_173 }}
+          DELTA_1000: ${{ needs.current.outputs.delta_1000 }}
+        run: |
+          set -euo pipefail
+          comment_file="$RUNNER_TEMP/pr-performance.md"
+          {
+            echo '<!-- f-sy-h-pr-performance -->'
+            echo '## PR highlighting performance'
+            echo
+            echo '| Buffer | Base | PR | Difference |'
+            echo '| ---: | ---: | ---: | ---: |'
+            echo "| 173 chars | ${BASE_173_MS} ms | ${PR_173_MS} ms | ${DELTA_173} |"
+            echo "| 1000 chars | ${BASE_1000_MS} ms | ${PR_1000_MS} ms | ${DELTA_1000} |"
+            echo
+            echo 'Negative differences are faster. Medians use nine parses after one warm-up on the same runner.'
+            echo
+            echo '### Behavioral assertions'
+            echo
+            echo '- Pass: representative buffers produce highlighting'
+            echo '- Pass: steady-state highlighting performs no full lifecycle refresh'
+            echo '- Pass: buffers above the configured limit take the skip path'
+            echo '- Pass: lazy and steady-state plugin resources unload cleanly'
+          } > "$comment_file"
+          ! rg -n -F '\n' "$comment_file"
+
+          comment_id=$(gh api \
+            "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --jq 'first(.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- f-sy-h-pr-performance -->")))) | .id // empty')
+          if [[ -n $comment_id ]]; then
+            gh api --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              -F "body=@$comment_file" >/dev/null
+          else
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -F "body=@$comment_file" >/dev/null
+          fi
 
   required:
     name: Zsh

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ zsh -f tests/integration/test-function-completion.zsh
 zsh -f tests/integration/test-git-chroma-regions.zsh
 zsh -f tests/integration/test-passive-safety.zsh
 zsh -f tests/integration/test-hostile-autoloads.zsh
-zsh -f tests/integration/test-highlight-budget.zsh
+zsh -f tests/integration/test-highlight-performance.zsh
 zsh -f tests/integration/test-theme-persistence.zsh
 zsh -f tests/integration/test-chroma-registry.zsh
 zsh -f tests/integration/test-chroma-regions.zsh
@@ -300,10 +300,12 @@ zsh -f tools/validate-themes.zsh
 zunit
 ```
 
-The highlight-budget profile measures nine parses of representative,
+The highlight-performance profile measures nine parses of representative,
 delimiter-free single commands at 173 and 1,000 characters after one warm-up
-run. Their medians must remain at or below 100 ms and 250 ms, respectively. A
-buffer above the default limit must take the skip path.
+run. Pull-request CI compares the medians with the base revision on the same
+runner and updates a PR comment with the relative difference. Hardware timing
+does not gate the build; empty highlighting, steady-state lifecycle refreshes,
+and failure to skip a buffer above the default limit remain test failures.
 
 `tools/validate-themes.zsh` validates all shipped themes by default and accepts
 explicit INI paths as arguments. It emits one JSON Lines record per result or

--- a/lib/highlight.zsh
+++ b/lib/highlight.zsh
@@ -411,7 +411,7 @@ _fsh_highlight_fill_option_variables() {
 _fsh_highlight_process() {
   builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global bare_glob_qual no_nomatch typeset_silent no_short_loops rc_quotes no_auto_pushd localtraps
-  builtin trap '_fsh_lifecycle_refresh' EXIT
+  builtin trap '_fsh_lifecycle_checkpoint' EXIT
 
   [[ $CONTEXT == "select" ]] && return 0
 

--- a/lib/lifecycle.zsh
+++ b/lib/lifecycle.zsh
@@ -91,12 +91,30 @@ _fsh_lifecycle_begin() {
   typeset -gA _fsh_lifecycle_original_functions=()
   typeset -gA _fsh_lifecycle_applied_function_set=()
   typeset -gA _fsh_lifecycle_applied_functions=()
+  typeset -gA _fsh_lifecycle_pending_autoloads=()
   typeset -gA _fsh_lifecycle_touched_functions=()
   typeset -gA _fsh_lifecycle_original_parameter_set=()
   typeset -gA _fsh_lifecycle_original_parameters=()
   typeset -gA _fsh_lifecycle_applied_parameter_set=()
   typeset -gA _fsh_lifecycle_applied_parameters=()
   typeset -gA _fsh_lifecycle_touched_parameters=()
+  # Highlighting owns the final values of these private runtime parameters.
+  typeset -gA _fsh_lifecycle_runtime_parameters=(
+    _fsh_assigns_seen 1
+    _fsh_command_output 1
+    _fsh_command_type_cache 1
+    _fsh_complex_brackets 1
+    _fsh_last_commands 1
+    _fsh_main_cache 1
+    _fsh_prior_buffer 1
+    _fsh_prior_cursor 1
+    _fsh_prior_region_active 1
+    _fsh_state 1
+    _fsh_style_ranges 1
+    _fsh_styles 1
+    _fsh_theme_name 1
+    _fsh_token_types 1
+  )
   typeset -gA _fsh_lifecycle_original_module_set=()
   typeset -ga _fsh_lifecycle_owned_modules=()
   typeset -ga _fsh_lifecycle_original_fpath=( "${fpath[@]}" )
@@ -174,6 +192,12 @@ _fsh_lifecycle_finalize() {
     _fsh_lifecycle_touched_functions[$name]=1
   done
 
+  _fsh_lifecycle_pending_autoloads=()
+  for name in ${(k)_fsh_lifecycle_touched_functions}; do
+    [[ ${_fsh_lifecycle_applied_functions[$name]-} == *'builtin autoload -X'* ]] &&
+      _fsh_lifecycle_pending_autoloads[$name]=1
+  done
+
   names=( ${(k)_fsh_lifecycle_original_parameter_set} )
   for name in ${(k)parameters}; do
     _fsh_lifecycle_parameter_owned "$name" && names+=( "$name" )
@@ -234,6 +258,28 @@ _fsh_lifecycle_refresh() {
 
   (( ${+parameters[_fsh_lifecycle_started]} && _fsh_lifecycle_started )) || return 0
   _fsh_lifecycle_finalize
+}
+
+_fsh_lifecycle_checkpoint() {
+  builtin emulate -L zsh
+
+  local name
+  local -A touched_parameters
+
+  (( ${+parameters[_fsh_lifecycle_started]} && _fsh_lifecycle_started )) || return 0
+
+  for name in ${(k)_fsh_lifecycle_pending_autoloads}; do
+    [[ ${functions[$name]-} == "${_fsh_lifecycle_applied_functions[$name]-}" ]] || {
+      # A materialized autoload may add more plugin-owned shell resources.
+      touched_parameters=( "${(@kv)_fsh_lifecycle_touched_parameters}" )
+      _fsh_lifecycle_refresh
+      for name in ${(k)_fsh_lifecycle_touched_parameters}; do
+        (( ${+touched_parameters[$name]} )) ||
+          _fsh_lifecycle_runtime_parameters[$name]=1
+      done
+      return
+    }
+  done
 }
 
 _fsh_lifecycle_restore_widget() {
@@ -333,13 +379,15 @@ _fsh_lifecycle_restore_parameters() {
   for name in ${(k)_fsh_lifecycle_touched_parameters}; do
     applied_set=${_fsh_lifecycle_applied_parameter_set[$name]:-0}
     applied=${_fsh_lifecycle_applied_parameters[$name]-}
-    if (( applied_set )); then
-      (( ${+parameters[$name]} )) || continue
-      _fsh_lifecycle_parameter_declaration "$name"
-      current=$REPLY
-      [[ $current == "$applied" ]] || continue
-    else
-      (( ${+parameters[$name]} )) && continue
+    if (( ! ${+_fsh_lifecycle_runtime_parameters[$name]} )); then
+      if (( applied_set )); then
+        (( ${+parameters[$name]} )) || continue
+        _fsh_lifecycle_parameter_declaration "$name"
+        current=$REPLY
+        [[ $current == "$applied" ]] || continue
+      else
+        (( ${+parameters[$name]} )) && continue
+      fi
     fi
 
     original_set=${+_fsh_lifecycle_original_parameter_set[$name]}
@@ -421,6 +469,7 @@ fsh_plugin_unload() {
     _fsh_lifecycle_capture_widgets
     _fsh_lifecycle_finalize
     _fsh_lifecycle_refresh
+    _fsh_lifecycle_checkpoint
     _fsh_lifecycle_restore_widget
     _fsh_lifecycle_restore_widgets
     _fsh_lifecycle_restore_functions
@@ -433,12 +482,14 @@ fsh_plugin_unload() {
   builtin unset _fsh_lifecycle_original_functions
   builtin unset _fsh_lifecycle_applied_function_set
   builtin unset _fsh_lifecycle_applied_functions
+  builtin unset _fsh_lifecycle_pending_autoloads
   builtin unset _fsh_lifecycle_touched_functions
   builtin unset _fsh_lifecycle_original_parameter_set
   builtin unset _fsh_lifecycle_original_parameters
   builtin unset _fsh_lifecycle_applied_parameter_set
   builtin unset _fsh_lifecycle_applied_parameters
   builtin unset _fsh_lifecycle_touched_parameters
+  builtin unset _fsh_lifecycle_runtime_parameters
   builtin unset _fsh_lifecycle_original_module_set
   builtin unset _fsh_lifecycle_owned_modules
   builtin unset _fsh_lifecycle_original_fpath

--- a/tests/integration/test-highlight-budget.zsh
+++ b/tests/integration/test-highlight-budget.zsh
@@ -26,6 +26,8 @@ typeset extension=' /usr/local/bin/foo --verbose --dry-run argument'
 typeset BUFFER= PREBUFFER= WIDGET=self-insert
 integer CURSOR=0 REGION_ACTIVE=0
 typeset -a region_highlight samples
+typeset lifecycle_refresh_definition=${functions[_fsh_lifecycle_refresh]}
+integer lifecycle_refresh_calls=0
 
 (( _fsh_max_length == 1000 ))
 (( ! ${+functions[_fsh_highlight_buffer]} ))
@@ -44,6 +46,10 @@ for length in 173 1000; do
   region_highlight=()
   _fsh_zle_highlight
   (( $#region_highlight > 0 ))
+
+  if (( length == 173 )); then
+    _fsh_lifecycle_refresh() { (( ++lifecycle_refresh_calls )); }
+  fi
 
   samples=()
   for run in {1..9}; do
@@ -71,6 +77,13 @@ for length in 173 1000; do
     exit 1
   fi
 done
+
+(( lifecycle_refresh_calls == 0 )) || {
+  builtin printf >&2 'f-sy-h: steady-state highlighting performed %d full lifecycle refreshes\n' \
+    $lifecycle_refresh_calls
+  exit 1
+}
+functions[_fsh_lifecycle_refresh]=$lifecycle_refresh_definition
 
 BUFFER+=$extension
 BUFFER=${BUFFER[1,_fsh_max_length + 1]}

--- a/tests/integration/test-highlight-performance.zsh
+++ b/tests/integration/test-highlight-performance.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+# Report timing for CI comparisons while enforcing deterministic behavior.
+
 emulate -R zsh
 setopt err_exit no_unset no_function_argzero posix_argzero
 
@@ -17,10 +19,8 @@ zstyle ':fsh:config' bracket-highlighting disabled
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
 
-float -r interactive_budget_seconds=0.100
-float -r cap_budget_seconds=0.250
 integer length run
-float started elapsed median budget_seconds
+float started elapsed median
 typeset pattern='echo this is a moderately long test command line with several arguments and some paths like /usr/local/bin/foo --verbose --dry-run'
 typeset extension=' /usr/local/bin/foo --verbose --dry-run argument'
 typeset BUFFER= PREBUFFER= WIDGET=self-insert
@@ -64,17 +64,9 @@ for length in 173 1000; do
 
   samples=( ${(on)samples} )
   median=$samples[5]
-  (( length == 173 )) && budget_seconds=$interactive_budget_seconds || \
-    budget_seconds=$cap_budget_seconds
 
   if [[ -n ${FSH_BENCHMARK_REPORT-} ]]; then
     builtin printf 'f-sy-h: %d chars median=%.6fs\n' $length $median
-  fi
-  if (( median > budget_seconds )); then
-    builtin printf >&2 \
-      'f-sy-h: median highlight time %.3fs exceeds %.3fs at %d characters\n' \
-      $median $budget_seconds $length
-    exit 1
   fi
 done
 

--- a/tests/integration/test-plugin-lifecycle.zsh
+++ b/tests/integration/test-plugin-lifecycle.zsh
@@ -137,6 +137,8 @@ _fsh_test_noninteractive() {
     local PREBUFFER= BUFFER='git status'
     _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0 ||
       _fsh_test_fail 'cannot exercise lazy chroma functions before unload'
+    _fsh_highlight_process '' 'echo changed runtime state' 0 ||
+      _fsh_test_fail 'cannot exercise steady-state highlighting before unload'
 
     for name in ${(k)widgets}; do
       [[ ${widgets[$name]} == "${before_widgets[$name]-}" ]] || {

--- a/tests/unit/main.zunit
+++ b/tests/unit/main.zunit
@@ -170,8 +170,8 @@ reply=()
     assert "$state" same_as "0"
 }
 
-@test 'default highlighting stays within the performance budget' {
-    run zsh -f ./tests/integration/test-highlight-budget.zsh
+@test 'default highlighting reports performance and preserves invariants' {
+    run zsh -f ./tests/integration/test-highlight-performance.zsh
 
     assert "$output" is_empty
     assert "$state" same_as "0"


### PR DESCRIPTION
## Summary

- replace the per-highlight full lifecycle inventory refresh with a bounded autoload checkpoint
- preserve exact unload cleanup for mutable runtime parameters and lazily materialized functions
- compare base and PR highlighting medians on the same runner and maintain a PR performance comment
- keep deterministic highlighting and lifecycle assertions while removing hardware-dependent timing gates

## Cause

The plugin-standard lifecycle refresh scanned all shell functions, parameters, widgets, modules, and `fpath` entries after every parser invocation. In a realistic shell this dominated the time between keystrokes.

## CI result

| Buffer | Base | PR | Difference |
| ---: | ---: | ---: | ---: |
| 173 chars | 38.602 ms | 4.649 ms | -88.0% |
| 1000 chars | 50.498 ms | 15.144 ms | -70.0% |

The workflow updates these values in a stable PR comment after each synchronized run.

## Verification

- all 14 integration profiles passed, including interactive lifecycle and async chroma coverage
- all 68 native Zsh sources passed `zsh -n` and `zcompile`
- all workflow files passed `actionlint`
- CodeQL, Trunk, ZUnit, Zsh 5.8, Zsh 5.9.2, and the PR comment job passed on the published commit

Refs #119
