### PR TITLE
fix(ci): use current base performance profile

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -155,7 +155,7 @@ jobs:
           git worktree add --detach "$base_dir" "$BASE_SHA"
 
           base_output=$(FSH_BENCHMARK_REPORT=1 \
-            zsh -f "$base_dir/tests/integration/test-highlight-budget.zsh") || true
+            zsh -f "$base_dir/tests/integration/test-highlight-performance.zsh") || true
           pr_output=$(FSH_BENCHMARK_REPORT=1 \
             zsh -f tests/integration/test-highlight-performance.zsh)
 


### PR DESCRIPTION
## Summary

- run the existing performance profile from the pull request base worktree

## Cause

PR #123 renamed the profile to `test-highlight-performance.zsh`, but its new
base-versus-PR comparison retained the deleted filename for the base run.

## Verification

- `actionlint .github/workflows/zsh-n.yml`
- `trunk check .github/workflows/zsh-n.yml --no-progress`
- local base and PR metric extraction produced both required buffer metrics
- `git diff --check`

Closes #125
