### PR TITLE
fix(themes): make previews transient

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -125,6 +125,13 @@ _fsh_zle_highlight() {
   builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd localtraps
 
+  if (( ${+_fsh_preview_theme_name} && ${+_fsh_preview_styles} )); then
+    local _fsh_theme_name=$_fsh_preview_theme_name
+    local -A _fsh_styles=( "${(@kv)_fsh_preview_styles}" )
+  fi
+
+  {
+
   # Remove all highlighting in isearch, so that only the underlining done by zsh itself remains.
   # For details see FAQ entry 'Why does syntax highlighting not work while searching history?'.
   if [[ $WIDGET == zle-isearch-update ]] && ! (( $+ISEARCHMATCH_ACTIVE )); then
@@ -206,6 +213,11 @@ _fsh_zle_highlight() {
     typeset -g _fsh_prior_buffer="$BUFFER"
     typeset -g _fsh_prior_region_active="$REGION_ACTIVE"
     typeset -gi _fsh_prior_cursor=$CURSOR
+  }
+  } always {
+    if [[ $WIDGET == zle-line-finish ]]; then
+      builtin unset _fsh_preview_theme_name _fsh_preview_styles 2>/dev/null || true
+    fi
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -240,11 +240,16 @@ List available themes:
 fsh_theme --list
 ```
 
-Test a theme for the current session:
+Preview a theme on the next command line:
 
 ```zsh
 fsh_theme --test clean
 ```
+
+Previewing does not change the active theme or saved theme files. Inspection
+commands (`--help`, `--info`, `--palette`, `--list`, and `--show`) also leave
+the theme work directory untouched. `fsh_theme --show` reports both the active
+and session-startup theme names and source paths.
 
 Apply a theme:
 
@@ -273,9 +278,10 @@ widget, function, or parameter changed after loading is preserved.
 
 Loading performs no network request and does not create the cache directory.
 The explicit `fsh_theme` command creates storage only when it needs to write
-theme state. Saved state uses `current_theme.ini`, `theme_overlay.ini`, and
-`secondary_theme.local.ini`. These files are parsed as data. Legacy writable
-`*.zsh` theme caches are deliberately ignored and never sourced.
+theme state. Preview and inspection do not create it. Saved state uses
+`current_theme.ini`, `theme_overlay.ini`, and `secondary_theme.local.ini`.
+These files are parsed as data. Legacy writable `*.zsh` theme caches are
+deliberately ignored and never sourced.
 
 ## Verification
 

--- a/functions/fsh_theme
+++ b/functions/fsh_theme
@@ -50,11 +50,6 @@ map=( "CONFIG:" "${XDG_CONFIG_HOME:-$HOME/.config}/f-sy-h/"
 
 _fsh_work_dir=${${_fsh_work_dir/(#m)(#s)(CONFIG|CACHE|LOCAL|HOME|OPT):(#c0,1)/${map[${MATCH%:}:]}}%/}
 
-[[ -d $_fsh_work_dir ]] || command mkdir -p -- "$_fsh_work_dir" || {
-  print -u2 "f-sy-h: cannot create working directory $_fsh_work_dir"
-  return 1
-}
-
 local OPT_HELP OPT_INFO OPT_VERBOSE OPT_QUIET OPT_RESET OPT_LIST OPT_TEST OPT_SECONDARY OPT_SHOW OPT_COPY OPT_OV_RESET
 local OPT_PALETTE OPT_CDWD OPT_XCHG OPT_OV_XCHG
 local -A opthash
@@ -77,11 +72,25 @@ zparseopts -E -D -A opthash h -help v -verbose q -quiet i -info r -reset l -list
 (( ${+opthash[-x]} + ${+opthash[--xchg]} ))    && OPT_XCHG="-x"
 (( ${+opthash[-y]} + ${+opthash[--ov-xchg]} )) && OPT_OV_XCHG="-y"
 
+local preview_root=
+if [[ -n $OPT_TEST && -z ${_fsh_theme_preview_active-} ]]; then
+  local preview_theme_name=${_fsh_theme_name-}
+  local -A preview_styles=( "${(@kv)_fsh_styles}" )
+  local _fsh_theme_preview_active=1
+  local _fsh_theme_name=$preview_theme_name
+  local -A _fsh_styles=( "${(@kv)preview_styles}" )
+  preview_root=1
+fi
+
 local -a match mbegin mend
 local MATCH; integer MBEGIN MEND
 
 if [[ -n "$OPT_CDWD" ]]; then
-  builtin cd $_fsh_work_dir
+  [[ -d $_fsh_work_dir ]] || command mkdir -p -- "$_fsh_work_dir" || {
+    print -u2 "f-sy-h: cannot create working directory $_fsh_work_dir"
+    return 1
+  }
+  builtin cd -- "$_fsh_work_dir"
   return 0
 fi
 
@@ -123,10 +132,17 @@ fi
 
 if [[ -n "$OPT_SHOW" ]]; then
   local -A saved_theme
-  print -r -- "Currently active theme: ${fg_bold[green]}$_fsh_theme_name$reset_color"
+  local active_source=${_fsh_styles[${_fsh_theme_name}-path]-}
   if [[ -r "$_fsh_work_dir/current_theme.ini" ]] &&
     _fsh_read_ini "$_fsh_work_dir/current_theme.ini" saved_theme ''; then
+    [[ -z $active_source && $_fsh_theme_name == ${saved_theme[<theme>_name]-} ]] &&
+      active_source=${saved_theme[<theme>_path]-}
+  fi
+  print -r -- "Currently active theme: ${fg_bold[green]}${_fsh_theme_name:-default}$reset_color"
+  print -r -- "Active theme source: ${active_source:-built-in defaults}"
+  if (( $#saved_theme )); then
     print -r -- "Main theme (session startup): ${fg_bold[green]}${saved_theme[<theme>_name]}$reset_color"
+    print -r -- "Startup theme source: ${saved_theme[<theme>_path]:-unknown}"
   else
     print -r -- 'No main theme is set'
   fi
@@ -174,8 +190,8 @@ if [[ -n "$OPT_HELP" ]]; then
   print -r -- "   ${fg[cyan]}-R, --ov-reset$reset_color  - unset overlay, use styles only from main-theme (requires restart)"
   print -r -- "   ${fg[cyan]}-p, --palette$reset_color   - just print all 256 colors and exit (useful when creating a theme)"
   print -r -- "   ${fg[cyan]}-r, --reset$reset_color     - unset any theme, use default highlighting (requires restart)"
-  print -r -- "   ${fg[cyan]}-t, --test$reset_color      - show test block of code after switching theme"
-  print -r -- "   ${fg[cyan]}-s, --show$reset_color      - get and display the theme currently being set"
+  print -r -- "   ${fg[cyan]}-t, --test$reset_color      - preview a theme without changing saved or active state"
+  print -r -- "   ${fg[cyan]}-s, --show$reset_color      - display active and startup theme names and sources"
   print -r -- "   ${fg[cyan]}-w, --workdir$reset_color   - cd into the configured theme work directory"
   print -r -- "   ${fg[cyan]}-l, --list$reset_color      - list names of available themes"
   print -r -- "   ${fg[cyan]}-v, --verbose$reset_color   - more messages during operation"
@@ -244,8 +260,15 @@ fi
 local outfile output_path
 [[ -z "$OPT_SECONDARY" ]] && { [[ "$THEME_NAME" = *"overlay"* ]] && outfile="theme_overlay.ini" || outfile="current_theme.ini"; } || outfile="secondary_theme.local.ini"
 
-# Set the runtime theme name. Persisted theme state is written as INI data.
-if [[ -z "$OPT_SECONDARY" && -z "$OPT_XCHG" && -z "$OPT_OV_XCHG" ]]; then
+# Set the runtime theme name. Preview state is dynamically scoped so recursive
+# secondary-theme loading cannot change the active theme.
+if [[ -n ${_fsh_theme_preview_active-} ]]; then
+  if [[ -n $OPT_SECONDARY ]]; then
+    local _fsh_theme_name="$THEME_NAME"
+  elif [[ "$THEME_NAME" != *"overlay"* ]]; then
+    _fsh_theme_name="$THEME_NAME"
+  fi
+elif [[ -z "$OPT_SECONDARY" && -z "$OPT_XCHG" && -z "$OPT_OV_XCHG" ]]; then
   [[ "$THEME_NAME" != *"overlay"* ]] && {
     typeset -g _fsh_theme_name="$THEME_NAME"
   }
@@ -258,15 +281,19 @@ if [[ -n $secondary_name ]]; then
 fi
 
 # Store from which file the theme or overlay is being loaded
-[[ "$THEME_NAME" != *"overlay" && -z "$OPT_OV_XCHG" ]] && _fsh_styles[${_fsh_theme_name}-path]="$THEME_PATH" || _fsh_styles[${_fsh_theme_name}-ov-path]="$THEME_PATH"
+[[ "$THEME_NAME" != *"overlay" && -z "$OPT_OV_XCHG" ]] && _fsh_styles[${_fsh_theme_name}-path]="$theme_source" || _fsh_styles[${_fsh_theme_name}-ov-path]="$theme_source"
 
-if [[ -z "$OPT_XCHG$OPT_OV_XCHG" ]]; then
+if [[ -z "$OPT_XCHG$OPT_OV_XCHG" && -z ${_fsh_theme_preview_active-} ]]; then
+  [[ -d $_fsh_work_dir ]] || command mkdir -p -- "$_fsh_work_dir" || {
+    print -u2 "f-sy-h: cannot create working directory $_fsh_work_dir"
+    return 1
+  }
   output_path="$_fsh_work_dir/$outfile"
   temp_output_path=$(command mktemp "$_fsh_work_dir/.${outfile}.XXXXXXXX") || return 1
   {
     print -r -- '[theme]'
     print -r -- "name=$THEME_NAME"
-    print -r -- "path=$THEME_PATH"
+    print -r -- "path=$theme_source"
     print -r -- '[styles]'
   } >| "$temp_output_path" || return 1
 fi
@@ -346,7 +373,7 @@ for k in "${order[@]}"; do
 
   if [[ "$THEME_NAME" = *"overlay"* || -n "$OPT_OV_XCHG" ]]; then
     (( ++ ov_counter ))
-    if [[ -z "$OPT_XCHG$OPT_OV_XCHG" ]]; then
+    if [[ -z "$OPT_XCHG$OPT_OV_XCHG" && -z ${_fsh_theme_preview_active-} ]]; then
       print -r -- "${_fsh_theme_name}${k}=$result" >>! "$temp_output_path" || return 1
     fi
     # ORIG: Save original value of the overwritten style
@@ -354,7 +381,7 @@ for k in "${order[@]}"; do
     # Overwrite theme's style
     _fsh_styles[${_fsh_theme_name}$k]="$result"
   else
-    if [[ -z "$OPT_XCHG$OPT_OV_XCHG" ]]; then
+    if [[ -z "$OPT_XCHG$OPT_OV_XCHG" && -z ${_fsh_theme_preview_active-} ]]; then
       print -r -- "${_fsh_theme_name}${k}=$result" >>! "$temp_output_path" || return 1
     fi
     _fsh_styles[${_fsh_theme_name}$k]="$result"
@@ -371,8 +398,15 @@ fi
 [[ "$THEME_NAME" != *"overlay"* ]] && [[ -r "$_fsh_work_dir/theme_overlay.ini" ]] &&
   _fsh_theme_load_data "$_fsh_work_dir/theme_overlay.ini" 0
 
+if [[ -n $preview_root ]]; then
+  typeset -g _fsh_preview_theme_name=$_fsh_theme_name
+  typeset -gA _fsh_preview_styles=( "${(@kv)_fsh_styles}" )
+fi
+
 if [[ -z "$OPT_QUIET" ]]; then
-  if [[ "$THEME_NAME" != *"overlay"* ]]; then
+  if [[ -n $preview_root ]]; then
+    print "Previewing theme \`$THEME_NAME' for the next command line"
+  elif [[ "$THEME_NAME" != *"overlay"* ]]; then
     print "Switched to theme \`$THEME_NAME' (current session, and future sessions)" || \
   else
     print "Processed the overlay ($ov_counter keys found), it is now active (for current session, and future sessions)"

--- a/tests/integration/test-theme-persistence.zsh
+++ b/tests/integration/test-theme-persistence.zsh
@@ -3,9 +3,31 @@
 emulate -R zsh
 setopt err_exit no_unset no_function_argzero posix_argzero
 
+typeset -g _fsh_test_file=${${(%):-%N}:A}
+TRAPZERR() {
+  [[ ${${funcfiletrace[1]%:*}:A} == $_fsh_test_file ]] || return 0
+  builtin print -u2 -r -- \
+    "f-sy-h: theme persistence check failed at line ${funcfiletrace[1]##*:}"
+}
+
 typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
 typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-themes.XXXXXXXX")
 trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+_fsh_test_read_until() {
+  local pty_name=$1 pattern=$2 chunk
+  integer deadline=$(( SECONDS + 15 ))
+  REPLY=
+  while (( SECONDS < deadline )); do
+    if zpty -r -t "$pty_name" chunk; then
+      REPLY+=$chunk
+      [[ $REPLY == ${~pattern} ]] && return 0
+    else
+      command sleep 0.02
+    fi
+  done
+  return 1
+}
 
 typeset theme theme_file theme_work output
 for theme_file in "$plugin_root"/themes/*.ini(N); do
@@ -14,6 +36,8 @@ for theme_file in "$plugin_root"/themes/*.ini(N); do
   command mkdir -p -- "$theme_work/zdotdir"
   output=$(ZDOTDIR=$theme_work/zdotdir XDG_CACHE_HOME=$theme_work/cache-home \
     zsh -f -c '
+      fpath=( "$2/functions" $fpath )
+      unfunction fsh_theme 2>/dev/null || true
       zstyle ":fsh:config" work-dir "$1"
       source "$2/F-Sy-H.plugin.zsh"
       fsh_theme --quiet "$3"
@@ -32,6 +56,8 @@ done
 
 output=$(ZDOTDIR=$fixture_root/list-zdotdir XDG_CACHE_HOME=$fixture_root/list-cache \
   zsh -f -c '
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
     zstyle ":fsh:config" work-dir "$1"
     source "$2/F-Sy-H.plugin.zsh"
     fsh_theme --list
@@ -40,10 +66,33 @@ output=$(ZDOTDIR=$fixture_root/list-zdotdir XDG_CACHE_HOME=$fixture_root/list-ca
 [[ $output == *Theme*Background* ]]
 [[ $output == *light*'#ffffff'* ]]
 
+theme_work=$fixture_root/inspection-work
+output=$(ZDOTDIR=$fixture_root/inspection-zdotdir XDG_CACHE_HOME=$fixture_root/inspection-cache \
+  zsh -f -c '
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    typeset operation
+    for operation in --help --info --palette --list --show --reset --ov-reset; do
+      fsh_theme "$operation" >/dev/null
+    done
+    fsh_theme --test --quiet clean
+    [[ $_fsh_preview_theme_name == clean ]]
+    [[ ! -e $1 ]]
+    fsh_plugin_unload
+  ' zsh "$theme_work" "$plugin_root" 2>&1) || {
+    builtin print -u2 -r -- "f-sy-h: inspection created theme storage: $output"
+    exit 1
+  }
+[[ -z $output ]]
+
 theme_work=$fixture_root/base16/work
 output=$(ZDOTDIR=$fixture_root/reload-zdotdir XDG_CACHE_HOME=$fixture_root/reload-cache \
   zsh -f -c '
     setopt err_exit no_unset
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
     zstyle ":fsh:config" work-dir "$1"
     source "$2/F-Sy-H.plugin.zsh"
     [[ $_fsh_theme_name == base16 ]]
@@ -71,12 +120,77 @@ output=$(ZDOTDIR=$fixture_root/reload-zdotdir XDG_CACHE_HOME=$fixture_root/reloa
   exit 1
 }
 
+{
+  builtin print -r -- '[styles]'
+  builtin print -r -- 'command = red'
+} >| "$fixture_root/test-overlay.ini"
+
+theme_work=$fixture_root/preview/work
+output=$(ZDOTDIR=$fixture_root/preview-zdotdir XDG_CACHE_HOME=$fixture_root/preview-cache \
+  zsh -f -c '
+    setopt err_exit no_unset
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    fsh_theme --quiet default
+    fsh_theme --quiet "$3"
+
+    typeset show_output=$(fsh_theme --show)
+    [[ $show_output == *"Currently active theme:"*default* ]]
+    [[ $show_output == *"Active theme source: $2/themes/default.ini"* ]]
+    [[ $show_output == *"Main theme (session startup):"*default* ]]
+    [[ $show_output == *"Startup theme source: $2/themes/default.ini"* ]]
+
+    typeset before_name=$_fsh_theme_name
+    typeset before_styles=$(typeset -p _fsh_styles)
+    typeset state_file
+    for state_file in current_theme.ini secondary_theme.local.ini theme_overlay.ini; do
+      command cp -- "$1/$state_file" "$1/$state_file.before"
+    done
+
+    fsh_theme --test --quiet clean
+    [[ $_fsh_theme_name == $before_name ]]
+    [[ $(typeset -p _fsh_styles) == $before_styles ]]
+    [[ $_fsh_preview_theme_name == clean ]]
+    [[ ${_fsh_preview_styles[cleancommand]} == fg=109 ]]
+    [[ ${_fsh_preview_styles[cleansecondary]} == zdharma ]]
+    [[ ${_fsh_preview_styles[zdharmacommand]} == fg=63 ]]
+    [[ ${_fsh_preview_styles[clean-path]} == "$2/themes/clean.ini" ]]
+    (( ! ${+_fsh_theme_preview_active} ))
+    for state_file in current_theme.ini secondary_theme.local.ini theme_overlay.ini; do
+      command cmp -s -- "$1/$state_file.before" "$1/$state_file"
+    done
+
+    typeset BUFFER=echo PREBUFFER= WIDGET=self-insert
+    integer CURSOR=4 PENDING=0 REGION_ACTIVE=0 MARK=0
+    typeset -a region_highlight=()
+    _fsh_zle_highlight
+    [[ ${region_highlight[(r)*fg=109*]} == *fg=109* ]]
+    [[ $_fsh_theme_name == $before_name ]]
+    [[ $(typeset -p _fsh_styles) == $before_styles ]]
+
+    WIDGET=zle-line-finish
+    _fsh_zle_highlight
+    (( ! ${+_fsh_preview_theme_name} && ! ${+_fsh_preview_styles} ))
+    fsh_plugin_unload
+  ' zsh "$theme_work" "$plugin_root" "$fixture_root/test-overlay.ini" 2>&1) || {
+    builtin print -u2 -r -- "f-sy-h: theme preview changed persistent or active state: $output"
+    exit 1
+  }
+[[ -z $output ]] || {
+  builtin print -u2 -r -- "f-sy-h: theme preview emitted output: $output"
+  exit 1
+}
+
 command sed \
   's/^; secondary[[:blank:]]*=.*$/secondary = does-not-exist/' \
   "$plugin_root/themes/base16.ini" >| "$fixture_root/invalid.ini"
 command mkdir -p -- "$fixture_root/invalid-zdotdir"
 if output=$(ZDOTDIR=$fixture_root/invalid-zdotdir XDG_CACHE_HOME=$fixture_root/invalid-cache \
   zsh -f -c '
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
     zstyle ":fsh:config" work-dir "$1"
     source "$2/F-Sy-H.plugin.zsh"
     fsh_theme --quiet "$3"
@@ -84,5 +198,67 @@ if output=$(ZDOTDIR=$fixture_root/invalid-zdotdir XDG_CACHE_HOME=$fixture_root/i
   builtin print -u2 -r -- 'f-sy-h: invalid secondary theme unexpectedly succeeded'
   exit 1
 fi
-[[ $output == *'missing-secondary: secondary theme does not exist: does-not-exist'* ]]
+[[ $output == *'missing-secondary: secondary theme does not exist: does-not-exist'* ]] || {
+  builtin print -u2 -r -- "f-sy-h: invalid secondary diagnostic mismatch: $output"
+  exit 1
+}
 [[ ! -e $fixture_root/invalid-work/current_theme.ini ]]
+
+zmodload zsh/zpty
+typeset -r pty_name=fsyh-theme-preview
+typeset -r preview_marker=$fixture_root/preview-render
+command mkdir -p -- "$fixture_root/pty-home" "$fixture_root/pty-zdotdir"
+zpty -b "$pty_name" \
+  "HOME=${(q)fixture_root}/pty-home ZDOTDIR=${(q)fixture_root}/pty-zdotdir zsh -f -i"
+{
+  zpty -w "$pty_name" \
+    "fpath=( ${(q)plugin_root}/functions \$fpath ); unfunction fsh_theme 2>/dev/null || true; zstyle ':fsh:config' work-dir ${(q)fixture_root}/pty-work; source ${(q)plugin_root}/F-Sy-H.plugin.zsh; _fsh_test_capture_preview() { BUFFER=echo; CURSOR=4; _fsh_zle_highlight; builtin print -r -- \"\${_fsh_preview_theme_name-}:\${region_highlight[(r)*fg=109*]-missing}\" >| ${(q)preview_marker}; }; zle -N _fsh_test_capture_preview; bindkey '^X^P' _fsh_test_capture_preview; PS1='FSH_PREVIEW> '; unsetopt prompt_cr prompt_sp; print -r -- FSH_PREVIEW_LOADED"
+  _fsh_test_read_until "$pty_name" '*FSH_PREVIEW_LOADED*FSH_PREVIEW>*' || {
+    builtin print -u2 -r -- "f-sy-h: preview PTY did not load: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+
+  zpty -w "$pty_name" 'fsh_theme --test --quiet clean'
+  _fsh_test_read_until "$pty_name" '*fsh_theme --test --quiet clean*./configure*' || {
+    builtin print -u2 -r -- "f-sy-h: preview command did not reach ZLE: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+  zpty -w -n "$pty_name" $'\C-X\C-P'
+  integer marker_deadline=$(( SECONDS + 10 ))
+  while [[ ! -e $preview_marker ]] && (( SECONDS < marker_deadline )); do
+    command sleep 0.02
+  done
+  [[ -e $preview_marker ]]
+  [[ $(<$preview_marker) == 'clean:0 4 fg=109' ]]
+  [[ ! -e $fixture_root/pty-work ]]
+
+  zpty -w -n "$pty_name" $'\C-C'
+  _fsh_test_read_until "$pty_name" '*FSH_PREVIEW>*' || {
+    builtin print -u2 -r -- "f-sy-h: preview abort did not return to the prompt: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+  zpty -w "$pty_name" 'print -r -- "FSH_ABORT:${+_fsh_preview_theme_name}:${+_fsh_preview_styles}"'
+  _fsh_test_read_until "$pty_name" '*FSH_ABORT:0:0*' || {
+    builtin print -u2 -r -- "f-sy-h: preview state survived Ctrl-C: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+
+  zpty -w "$pty_name" 'fsh_theme --test --quiet clean'
+  _fsh_test_read_until "$pty_name" '*fsh_theme --test --quiet clean*./configure*' || {
+    builtin print -u2 -r -- "f-sy-h: second preview did not reach ZLE: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+  zpty -w -n "$pty_name" $'\C-U'
+  zpty -w "$pty_name" ':'
+  _fsh_test_read_until "$pty_name" '*FSH_PREVIEW>*' || {
+    builtin print -u2 -r -- "f-sy-h: preview acceptance did not return to the prompt: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+  zpty -w "$pty_name" 'print -r -- "FSH_ACCEPT:${+_fsh_preview_theme_name}:${+_fsh_preview_styles}"'
+  _fsh_test_read_until "$pty_name" '*FSH_ACCEPT:0:0*' || {
+    builtin print -u2 -r -- "f-sy-h: preview state survived acceptance: ${(V)REPLY[1,1000]}"
+    exit 1
+  }
+} always {
+  zpty -d "$pty_name" 2>/dev/null || true
+}


### PR DESCRIPTION
# Pull request

## Summary

- make `fsh_theme --test` render a one-line preview without changing active or persisted theme state
- keep inspection and reset operations from creating the theme work directory
- report active and startup theme source paths through `fsh_theme --show`
- cover preview rendering and cleanup after accepted input and Ctrl-C

Closes #92

## Verification

- `zsh -f -n F-Sy-H.plugin.zsh functions/fsh_theme tests/integration/test-theme-persistence.zsh`
- all 14 integration profiles
- ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 21 passed, 0 failed
- `zsh -f tools/validate-themes.zsh`
- native `zcompile` and `zcompile -t` for all changed Zsh files
- `git diff --check`

## Compatibility and lifecycle

The Zsh 5.8 compatibility floor and dependency set are unchanged. Preview
styles use the existing F-Sy-H widget wrapper and are removed by
`zle-line-finish`; no additional ZLE hook manager is installed. Inspection
commands remain read-only, and normal theme persistence is unchanged apart
from recording resolved source paths.

## Agent handoff

No handoff needed.
