### PR TITLE
feat(themes): add gallery and discovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ List available themes:
 fsh_theme --list
 ```
 
+The listing includes each theme's intended background, whether its palette is
+fixed or terminal-owned, and a short description.
+
+Compare every shipped theme using the same highlighted sample:
+
+```zsh
+fsh_theme --gallery
+```
+
 Preview a theme on the next command line:
 
 ```zsh
@@ -247,9 +256,11 @@ fsh_theme --test clean
 ```
 
 Previewing does not change the active theme or saved theme files. Inspection
-commands (`--help`, `--info`, `--palette`, `--list`, and `--show`) also leave
-the theme work directory untouched. `fsh_theme --show` reports both the active
-and session-startup theme names and source paths.
+commands (`--help`, `--info`, `--palette`, `--list`, `--gallery`, and `--show`)
+also leave the theme work directory untouched. The gallery preserves an
+existing one-shot preview as well as the active and saved themes.
+`fsh_theme --show` reports both the active and session-startup theme names and
+source paths.
 
 Apply a theme:
 
@@ -322,14 +333,15 @@ by the installed Zsh `zsh/nearcolor` module. It is empty when the theme has no
 truecolor styles; an unavailable module produces a structured
 `nearcolor-unavailable` error.
 
-Every shipped theme declares a `[theme]` rendering contract. Fixed-palette
-themes use `palette = xterm-256` with exact `foreground` and `background`
-`#rrggbb` values. Their resolved ordinary styles must reach a contrast ratio of
-4.5:1; `unknown-token`, `incorrect-subtle`, and `matherr` must reach 7:1.
-`palette = terminal-ansi16` is adaptive and restricts colors to terminal-owned
-ANSI indices 0 through 15 instead of claiming a fixed contrast ratio. Metadata
-remains optional for external themes, preserving existing user themes; when it
-is present, the same validation contract applies.
+Every shipped theme declares a `[theme]` rendering contract and a one-line
+`description`. Fixed-palette themes use `palette = xterm-256` with exact
+`foreground` and `background` `#rrggbb` values. Their resolved ordinary styles
+must reach a contrast ratio of 4.5:1; `unknown-token`, `incorrect-subtle`, and
+`matherr` must reach 7:1. `palette = terminal-ansi16` is adaptive and restricts
+colors to terminal-owned ANSI indices 0 through 15 instead of claiming a fixed
+contrast ratio. Rendering metadata and descriptions remain optional for
+external themes, preserving existing user themes. A supplied rendering
+contract receives the same validation as a shipped theme.
 
 That contract also keeps semantically opposed styles distinguishable. The
 validator compares resolved rendering state rather than raw INI text, so named

--- a/completions/_fsh_theme
+++ b/completions/_fsh_theme
@@ -25,6 +25,7 @@ arguments=(
   {-v,--verbose}'[more messages during operation]'
   {-i,--info}'[additional information]'
   {-l,--list}'[list available themes]'
+  {-g,--gallery}'[compare all shipped themes using a common sample]'
   {-q,--quiet}'[no default messages]'
   {-h,--help}'[display help text]'
 )

--- a/functions/_fsh_validate_theme
+++ b/functions/_fsh_validate_theme
@@ -16,9 +16,10 @@ builtin emulate -L zsh
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 local theme_path=$1 theme_dir=$2 validation_mode=${3:-} style_mode full_key declared_key style candidate inikey value token
-local secondary_key secondary_name secondary_path required_key error metadata_key palette foreground background
+local secondary_key secondary_name secondary_path required_key error metadata_key palette foreground background description
 local -A known declared_seen metadata_seen
-local -a candidates style_colors metadata_keys
+local -a candidates style_colors metadata_keys rendering_metadata_keys
+integer rendering_metadata_count=0
 
 typeset -gA _fsh_validated_theme_data=()
 typeset -ga _fsh_theme_validation_errors=()
@@ -42,6 +43,7 @@ _fsh_read_ini "$theme_path" _fsh_validated_theme_data '' || {
 
 style_colors=( red green blue yellow cyan magenta black white default )
 metadata_keys=( "${_fsh_theme_metadata_keys[@]}" )
+rendering_metadata_keys=( "${_fsh_theme_rendering_metadata_keys[@]}" )
 for style in "${_fsh_theme_style_order[@]}"; do
   known[$style]=1
   for candidate in ${(s. .)_fsh_theme_style_fallbacks[$style]}; do
@@ -116,6 +118,7 @@ fi
 palette=${_fsh_validated_theme_data[<theme>_palette]-}
 foreground=${_fsh_validated_theme_data[<theme>_foreground]-}
 background=${_fsh_validated_theme_data[<theme>_background]-}
+description=${_fsh_validated_theme_data[<theme>_description]-}
 if [[ $validation_mode == shipped ]]; then
   for metadata_key in "${metadata_keys[@]}"; do
     (( ${+metadata_seen[$metadata_key]} )) ||
@@ -124,16 +127,24 @@ if [[ $validation_mode == shipped ]]; then
   done
 fi
 
-if (( $#metadata_seen && $#metadata_seen < $#metadata_keys )) &&
+for metadata_key in "${rendering_metadata_keys[@]}"; do
+  (( ${+metadata_seen[$metadata_key]} )) && (( ++rendering_metadata_count ))
+done
+if (( rendering_metadata_count && rendering_metadata_count < $#rendering_metadata_keys )) &&
   [[ $validation_mode != shipped ]]; then
-  for metadata_key in "${metadata_keys[@]}"; do
+  for metadata_key in "${rendering_metadata_keys[@]}"; do
     (( ${+metadata_seen[$metadata_key]} )) ||
       _fsh_theme_validation_errors+=(
         "incomplete-theme-metadata|missing [theme] declaration: $metadata_key" )
   done
 fi
 
-if (( $#metadata_seen == $#metadata_keys )); then
+if (( ${+metadata_seen[description]} )) && [[ -z $description ]]; then
+  _fsh_theme_validation_errors+=(
+    'invalid-theme-description|theme description must not be empty' )
+fi
+
+if (( rendering_metadata_count == $#rendering_metadata_keys )); then
   [[ $palette == (xterm-256|terminal-ansi16) ]] ||
     _fsh_theme_validation_errors+=(
       "invalid-theme-palette|unknown theme palette: $palette" )

--- a/functions/fsh_theme
+++ b/functions/fsh_theme
@@ -50,10 +50,10 @@ map=( "CONFIG:" "${XDG_CONFIG_HOME:-$HOME/.config}/f-sy-h/"
 
 _fsh_work_dir=${${_fsh_work_dir/(#m)(#s)(CONFIG|CACHE|LOCAL|HOME|OPT):(#c0,1)/${map[${MATCH%:}:]}}%/}
 
-local OPT_HELP OPT_INFO OPT_VERBOSE OPT_QUIET OPT_RESET OPT_LIST OPT_TEST OPT_SECONDARY OPT_SHOW OPT_COPY OPT_OV_RESET
+local OPT_HELP OPT_INFO OPT_VERBOSE OPT_QUIET OPT_RESET OPT_LIST OPT_GALLERY OPT_TEST OPT_SECONDARY OPT_SHOW OPT_COPY OPT_OV_RESET
 local OPT_PALETTE OPT_CDWD OPT_XCHG OPT_OV_XCHG
 local -A opthash
-zparseopts -E -D -A opthash h -help v -verbose q -quiet i -info r -reset l -list t -test -secondary s -show \
+zparseopts -E -D -A opthash h -help v -verbose q -quiet i -info r -reset l -list g -gallery t -test -secondary s -show \
 -copy-shipped-theme: R -ov-reset p -palette w -workdir x -xchg y -ov-xchg || return 1
 
 (( ${+opthash[-h]} + ${+opthash[--help]} ))    && OPT_HELP="-h"
@@ -62,6 +62,7 @@ zparseopts -E -D -A opthash h -help v -verbose q -quiet i -info r -reset l -list
 (( ${+opthash[-q]} + ${+opthash[--quiet]} ))   && OPT_QUIET="-q"
 (( ${+opthash[-r]} + ${+opthash[--reset]} ))   && OPT_RESET="-r"
 (( ${+opthash[-l]} + ${+opthash[--list]} ))    && OPT_LIST="-l"
+(( ${+opthash[-g]} + ${+opthash[--gallery]} )) && OPT_GALLERY="-g"
 (( ${+opthash[-t]} + ${+opthash[--test]} ))    && OPT_TEST="-t"
 (( ${+opthash[--secondary]} ))                 && OPT_SECONDARY="--secondary"
 (( ${+opthash[-s]} + ${+opthash[--show]} ))    && OPT_SHOW="-s"
@@ -164,26 +165,96 @@ fi
 
 if [[ -n "$OPT_LIST" ]]; then
   if [[ -z "$OPT_QUIET" ]]; then
-    local theme_path
+    local theme_path palette_owner
     local -A theme_metadata
     print -r -- "${fg_bold[yellow]}Available themes$reset_color:"
     print -r -- ""
-    builtin printf '%-20s %s\n' 'Theme' 'Background'
+    builtin printf '%-20s %-16s %-14s %s\n' 'Theme' 'Background' 'Palette' 'Description'
     for theme_path in "$_fsh_base_dir"/themes/*.ini(N); do
       theme_metadata=()
       _fsh_read_ini "$theme_path" theme_metadata '' || return 1
-      builtin printf '%-20s %s\n' \
-        "${theme_path:t:r}" "${theme_metadata[<theme>_background]:-unknown}"
+      case ${theme_metadata[<theme>_palette]-} in
+        xterm-256) palette_owner=fixed ;;
+        terminal-ansi16) palette_owner=terminal-owned ;;
+        *) palette_owner=unknown ;;
+      esac
+      builtin printf '%-20s %-16s %-14s %s\n' \
+        "${theme_path:t:r}" "${theme_metadata[<theme>_background]:-unknown}" \
+        "$palette_owner" "${theme_metadata[<theme>_description]:-No description}"
     done
     print -r -- ""
   fi
   return 0
 fi
 
+if [[ -n "$OPT_GALLERY" ]]; then
+  local theme_path gallery_theme gallery_style gallery_token gallery_prompt
+  local -a gallery_style_keys=( command subcommand double-hyphen-option single-quoted-argument comment )
+  local -a gallery_sample_parts=( 'git ' 'commit ' '--amend ' "'message' " '# comment' )
+  local saved_preview_theme_name=${_fsh_preview_theme_name-}
+  local -A saved_preview_styles
+  integer saved_preview_name_set=${+_fsh_preview_theme_name}
+  integer saved_preview_styles_set=${+_fsh_preview_styles}
+  (( saved_preview_styles_set && $#_fsh_preview_styles )) &&
+    saved_preview_styles=( "${(@kv)_fsh_preview_styles}" )
+
+  print -r -- "${fg_bold[yellow]}Theme gallery$reset_color:"
+  print -r -- ''
+  {
+    for theme_path in "$_fsh_base_dir"/themes/*.ini(N); do
+      gallery_theme=${theme_path:t:r}
+      local _fsh_theme_gallery_mode=1
+      fsh_theme --test --quiet "$gallery_theme" || return 1
+
+      gallery_prompt=
+      integer gallery_index
+      for gallery_index in {1..$#gallery_style_keys}; do
+        gallery_prompt+=$'\e[0m'
+        gallery_style=${_fsh_preview_styles[${_fsh_preview_theme_name}${gallery_style_keys[$gallery_index]}]-}
+        for gallery_token in ${(s:,:)gallery_style}; do
+          case $gallery_token in
+            fg=*) gallery_prompt+="%F{${gallery_token#fg=}}" ;;
+            bg=*) gallery_prompt+="%K{${gallery_token#bg=}}" ;;
+            bold) gallery_prompt+=$'\e[1m' ;;
+            no-bold) gallery_prompt+=$'\e[22m' ;;
+            underline) gallery_prompt+=$'\e[4m' ;;
+            no-underline) gallery_prompt+=$'\e[24m' ;;
+            (reverse|standout)) gallery_prompt+=$'\e[7m' ;;
+            (no-reverse|no-standout)) gallery_prompt+=$'\e[27m' ;;
+            blink) gallery_prompt+=$'\e[5m' ;;
+            no-blink) gallery_prompt+=$'\e[25m' ;;
+            conceal) gallery_prompt+=$'\e[8m' ;;
+            no-conceal) gallery_prompt+=$'\e[28m' ;;
+          esac
+        done
+        gallery_prompt+=$gallery_sample_parts[$gallery_index]
+      done
+      builtin printf '%-20s ' "$gallery_theme"
+      builtin print -Pr -- "$gallery_prompt"$'\e[0m'
+    done
+  } always {
+    if (( saved_preview_name_set )); then
+      typeset -g _fsh_preview_theme_name=$saved_preview_theme_name
+    else
+      builtin unset _fsh_preview_theme_name 2>/dev/null || true
+    fi
+    if (( saved_preview_styles_set )); then
+      if (( $#saved_preview_styles )); then
+        typeset -gA _fsh_preview_styles=( "${(@kv)saved_preview_styles}" )
+      else
+        typeset -gA _fsh_preview_styles=()
+      fi
+    else
+      builtin unset _fsh_preview_styles 2>/dev/null || true
+    fi
+  }
+  return 0
+fi
+
 if [[ -n "$OPT_HELP" ]]; then
   print -r -- "${fg_bold[yellow]}Usage$reset_color:"
   print -r -- "   ${fg[green]}fsh_theme$reset_color [-h/--help] [-v/--verbose] [-q/--quiet] [-t/--test] <theme-name|theme-path>"
-  print -r -- "   ${fg[green]}fsh_theme$reset_color [-r/--reset] [-l/--list] [-s/--show] [-p/--palette] [-w/--workdir]"
+  print -r -- "   ${fg[green]}fsh_theme$reset_color [-r/--reset] [-l/--list] [-g/--gallery] [-s/--show] [-p/--palette] [-w/--workdir]"
   print -r -- "   ${fg[green]}fsh_theme$reset_color --copy-shipped-theme {theme-name} [destination-path]"
   print -r -- ""
   print -r -- "${fg_bold[yellow]}Flags$reset_color:"
@@ -194,6 +265,7 @@ if [[ -n "$OPT_HELP" ]]; then
   print -r -- "   ${fg[cyan]}-s, --show$reset_color      - display active and startup theme names and sources"
   print -r -- "   ${fg[cyan]}-w, --workdir$reset_color   - cd into the configured theme work directory"
   print -r -- "   ${fg[cyan]}-l, --list$reset_color      - list names of available themes"
+  print -r -- "   ${fg[cyan]}-g, --gallery$reset_color   - compare all shipped themes using a common sample"
   print -r -- "   ${fg[cyan]}-v, --verbose$reset_color   - more messages during operation"
   print -r -- "   ${fg[cyan]}-i, --info$reset_color      - additional usage information"
   print -r -- "   ${fg[cyan]}-q, --quiet$reset_color     - no default messages"
@@ -413,7 +485,7 @@ if [[ -z "$OPT_QUIET" ]]; then
   fi
 fi
 
-if [[ -n "$OPT_TEST" ]]; then
+if [[ -n "$OPT_TEST" && -z ${_fsh_theme_gallery_mode-} ]]; then
   print -zr '
     # Sub-shell, assignments, math-mode
     echo $(cat /etc/hosts |& grep -i "hello337")

--- a/lib/theme-schema.zsh
+++ b/lib/theme-schema.zsh
@@ -80,10 +80,11 @@ typeset -ga _fsh_theme_style_order=(
   optarg-string optarg-number recursive-base
 )
 
-# Shipped themes declare their rendering assumptions. External themes may omit
-# this metadata for compatibility, but when it is present the validator applies
-# the same contract used by CI.
-typeset -ga _fsh_theme_metadata_keys=( palette foreground background )
+# Shipped themes declare their rendering assumptions and discovery text.
+# External themes may omit either for compatibility, but a partial rendering
+# contract is invalid because its palette cannot be checked safely.
+typeset -ga _fsh_theme_rendering_metadata_keys=( palette foreground background )
+typeset -ga _fsh_theme_metadata_keys=( palette foreground background description )
 typeset -g _fsh_theme_contrast_floor=4.5
 typeset -g _fsh_theme_critical_contrast_floor=7.0
 typeset -gA _fsh_theme_critical_styles=(

--- a/tests/integration/test-theme-persistence.zsh
+++ b/tests/integration/test-theme-persistence.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
 emulate -R zsh
-setopt err_exit no_unset no_function_argzero posix_argzero
+setopt err_exit no_unset no_function_argzero posix_argzero extended_glob
 
 typeset -g _fsh_test_file=${${(%):-%N}:A}
 TRAPZERR() {
@@ -29,7 +29,7 @@ _fsh_test_read_until() {
   return 1
 }
 
-typeset theme theme_file theme_work output
+typeset theme theme_file theme_work output plain_output gallery_line
 for theme_file in "$plugin_root"/themes/*.ini(N); do
   theme=${theme_file:t:r}
   theme_work=$fixture_root/$theme
@@ -63,8 +63,27 @@ output=$(ZDOTDIR=$fixture_root/list-zdotdir XDG_CACHE_HOME=$fixture_root/list-ca
     fsh_theme --list
     fsh_plugin_unload
   ' zsh "$fixture_root/list-work" "$plugin_root")
-[[ $output == *Theme*Background* ]]
-[[ $output == *light*'#ffffff'* ]]
+[[ $output == *Theme*Background*Palette*Description* ]]
+[[ $output == *base16*default*terminal-owned*'Terminal-adaptive ANSI 16-color theme.'* ]]
+[[ $output == *light*'#ffffff'*fixed*'GitHub-inspired light theme.'* ]]
+
+output=$(TERM=xterm-256color ZDOTDIR=$fixture_root/gallery-zdotdir \
+  XDG_CACHE_HOME=$fixture_root/gallery-cache \
+  zsh -f -c '
+    fpath=( "$2/functions" $fpath )
+    unfunction fsh_theme 2>/dev/null || true
+    zstyle ":fsh:config" work-dir "$1"
+    source "$2/F-Sy-H.plugin.zsh"
+    fsh_theme --gallery
+    fsh_plugin_unload
+  ' zsh "$fixture_root/gallery-work" "$plugin_root")
+[[ ! -e $fixture_root/gallery-work ]]
+plain_output=${output//$'\e'\[[0-9;]##m/}
+for theme_file in "$plugin_root"/themes/*.ini(N); do
+  theme=${theme_file:t:r}
+  gallery_line=${${(M)${(f)plain_output}:#$theme*}[1]-}
+  [[ $gallery_line == *"git commit --amend 'message' # comment"* ]]
+done
 
 theme_work=$fixture_root/inspection-work
 output=$(ZDOTDIR=$fixture_root/inspection-zdotdir XDG_CACHE_HOME=$fixture_root/inspection-cache \
@@ -74,7 +93,7 @@ output=$(ZDOTDIR=$fixture_root/inspection-zdotdir XDG_CACHE_HOME=$fixture_root/i
     zstyle ":fsh:config" work-dir "$1"
     source "$2/F-Sy-H.plugin.zsh"
     typeset operation
-    for operation in --help --info --palette --list --show --reset --ov-reset; do
+    for operation in --help --info --palette --list --gallery --show --reset --ov-reset; do
       fsh_theme "$operation" >/dev/null
     done
     fsh_theme --test --quiet clean
@@ -149,6 +168,13 @@ output=$(ZDOTDIR=$fixture_root/preview-zdotdir XDG_CACHE_HOME=$fixture_root/prev
       command cp -- "$1/$state_file" "$1/$state_file.before"
     done
 
+    fsh_theme --gallery >/dev/null
+    [[ $_fsh_theme_name == $before_name ]]
+    [[ $(typeset -p _fsh_styles) == $before_styles ]]
+    for state_file in current_theme.ini secondary_theme.local.ini theme_overlay.ini; do
+      command cmp -s -- "$1/$state_file.before" "$1/$state_file"
+    done
+
     fsh_theme --test --quiet clean
     [[ $_fsh_theme_name == $before_name ]]
     [[ $(typeset -p _fsh_styles) == $before_styles ]]
@@ -158,6 +184,11 @@ output=$(ZDOTDIR=$fixture_root/preview-zdotdir XDG_CACHE_HOME=$fixture_root/prev
     [[ ${_fsh_preview_styles[zdharmacommand]} == fg=63 ]]
     [[ ${_fsh_preview_styles[clean-path]} == "$2/themes/clean.ini" ]]
     (( ! ${+_fsh_theme_preview_active} ))
+    typeset preview_name=$_fsh_preview_theme_name
+    typeset preview_styles=$(typeset -p _fsh_preview_styles)
+    fsh_theme --gallery >/dev/null
+    [[ $_fsh_preview_theme_name == $preview_name ]]
+    [[ $(typeset -p _fsh_preview_styles) == $preview_styles ]]
     for state_file in current_theme.ini secondary_theme.local.ini theme_overlay.ini; do
       command cmp -s -- "$1/$state_file.before" "$1/$state_file"
     done

--- a/tests/integration/test-theme-validator.zsh
+++ b/tests/integration/test-theme-validator.zsh
@@ -88,6 +88,18 @@ output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
   "$fixture_root/custom-no-metadata.ini")
 [[ $output == *'"status":"ok"'* ]]
 
+command sed 's/^description =.*$/description =/' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/blank-description.ini"
+if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
+  "$fixture_root/blank-description.ini" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: blank theme description unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *'"code":"invalid-theme-description"'* ]]
+
+command sed '/^description =/d' \
+  "$plugin_root/themes/clean.ini" >| "$fixture_root/missing-description.ini"
+
 command sed '/^background = #000000$/d' "$plugin_root/themes/clean.ini" >| \
   "$fixture_root/incomplete-metadata.ini"
 if output=$(zsh -f "$plugin_root/tools/validate-themes.zsh" \
@@ -208,6 +220,13 @@ if _fsh_validate_theme "$fixture_root/custom-no-metadata.ini" \
   exit 1
 fi
 [[ ${_fsh_theme_validation_errors[*]} == *'missing-theme-metadata'* ]]
+
+if _fsh_validate_theme "$fixture_root/missing-description.ini" \
+  "$plugin_root/themes" shipped; then
+  builtin print -u2 -r -- 'f-sy-h: shipped validation accepted a missing description'
+  exit 1
+fi
+[[ ${_fsh_theme_validation_errors[*]} == *'missing [theme] declaration: description'* ]]
 
 typeset -a reply
 _fsh_theme_color_rgb 196 xterm-256

--- a/themes/base16.ini
+++ b/themes/base16.ini
@@ -2,6 +2,7 @@
 palette = terminal-ansi16
 foreground = default
 background = default
+description = Terminal-adaptive ANSI 16-color theme.
 
 [base]
 default          = none

--- a/themes/clean.ini
+++ b/themes/clean.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = High-contrast dark theme with muted accents.
 
 [base]
 default          = none

--- a/themes/default.ini
+++ b/themes/default.ini
@@ -4,6 +4,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Classic F-Sy-H dark theme.
 
 [base]
 default          = none

--- a/themes/forest.ini
+++ b/themes/forest.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Dark green theme with earthy accents.
 
 [base]
 default          = none

--- a/themes/free.ini
+++ b/themes/free.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Dark theme with cool blue and violet accents.
 
 [base]
 default          = none

--- a/themes/light.ini
+++ b/themes/light.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #24292f
 background = #ffffff
+description = GitHub-inspired light theme.
 
 [base]
 default          = none

--- a/themes/q-jmnemonic.ini
+++ b/themes/q-jmnemonic.ini
@@ -45,6 +45,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Vivid dark theme inspired by Johnny Mnemonic.
 
 [base]
 default           = none

--- a/themes/safari.ini
+++ b/themes/safari.ini
@@ -4,6 +4,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Dark theme with warm desert-oasis accents.
 
 [base]
 default          = none

--- a/themes/spa.ini
+++ b/themes/spa.ini
@@ -3,6 +3,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Soft dark theme with restful pastel accents.
 
 [base]
 default          = none

--- a/themes/sv-orple.ini
+++ b/themes/sv-orple.ini
@@ -21,6 +21,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Purple-toned SyntaxEnvy-inspired dark theme.
 
 [base]
 default          = none

--- a/themes/sv-plant.ini
+++ b/themes/sv-plant.ini
@@ -21,6 +21,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Plant-toned SyntaxEnvy-inspired dark theme.
 
 [base]
 default          = none

--- a/themes/z-shell.ini
+++ b/themes/z-shell.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Dark theme using the Z-Shell color palette.
 
 [base]
 default          = none

--- a/themes/zdharma.ini
+++ b/themes/zdharma.ini
@@ -2,6 +2,7 @@
 palette = xterm-256
 foreground = #ffffff
 background = #000000
+description = Dark theme using the original ZDharma palette.
 
 [base]
 default          = none


### PR DESCRIPTION
## Summary

- add optional theme descriptions while requiring them for shipped themes
- extend `fsh_theme --list` with palette ownership and descriptions
- add a non-destructive `fsh_theme --gallery` for all 13 shipped themes
- preserve active, persisted, and pending-preview state during discovery commands

## Verification

- native Zsh syntax and `zcompile` checks
- all repository integration profiles
- `zsh -f tools/validate-themes.zsh`
- `trunk check --no-progress`

## Known baseline

- The exact pinned ZUnit 0.8.2 runner stops after four passing tests on the unchanged `case` fixture (`fg=48` observed, `fg=141` expected). The same failure reproduces on the clean merged #92 baseline.
- Zsh 5.8 was unavailable locally and remains covered by CI.

Closes #127
