### PR TITLE
fix(ci): raise ZUnit test timeout

### DIFF
--- a/.zunit.yml
+++ b/.zunit.yml
@@ -1,6 +1,6 @@
 tap: false
 directories:
   tests: tests/unit
-time_limit: 15
+time_limit: 30
 fail_fast: true
 allow_risky: false


### PR DESCRIPTION
## Summary

- raise ZUnit's per-test timeout from 15 to 30 seconds
- retain every existing test assertion and workflow-level timeout
- prevent the expanded theme-persistence profile from flaking on hosted macOS

## Verification

- `zsh -f tests/integration/test-theme-persistence.zsh`
- exact pinned ZUnit 0.8.2: 21 passed, 0 failures, errors, warnings, or skips in 22.383 seconds
- `trunk check --no-progress .zunit.yml`
- `git diff --check origin/main...HEAD`

The failing `main` run is https://github.com/z-shell/F-Sy-H/actions/runs/33315356136. Ubuntu passed; macOS exceeded the former 15-second per-test limit.

Closes #130
