### PR TITLE
docs(themes): document Tinted Base16 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,19 @@ Apply a theme:
 fsh_theme clean
 ```
 
+### Match a Tinted Theming terminal palette
+
+If [Tinty](https://github.com/tinted-theming/tinty) or another Base16 manager
+sets your terminal's ANSI 16-color palette, select the shipped adaptive theme:
+
+```zsh
+fsh_theme base16
+```
+
+This theme uses the terminal-owned foreground, background, and ANSI colors, so
+changing the terminal scheme also changes F-Sy-H without generating or
+downloading another theme file.
+
 ## Lifecycle and side effects
 
 Interactive loading:


### PR DESCRIPTION
## Summary

- document the existing `fsh_theme base16` workflow for Tinty-managed terminal palettes
- explain that the adaptive theme follows terminal-owned foreground, background, and ANSI colors
- avoid a YAML parser, vendored schemes, generated themes, and another build dependency

## Verification

- `zsh -f tools/validate-themes.zsh`
- `zsh -f tests/integration/test-theme-validator.zsh`
- `zsh -f tests/integration/test-theme-persistence.zsh`
- `trunk check --no-progress README.md`
- `git diff --check`

Closes #89
