### PR TITLE
fix(chroma): resolve Makefile variables in targets

### DIFF
--- a/functions/_fsh_make_targets
+++ b/functions/_fsh_make_targets
@@ -9,14 +9,19 @@ builtin emulate -L zsh
 builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
 local -a TARGETS
+local -A VARIABLES
 
 _fsh_make_expand_vars() {
   builtin emulate -L zsh
   builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
 
   local open close var val front='' rest=$1
+  local -a seen
 
   while [[ $rest == (#b)[^$]#($)* ]]; do
+    (( ${seen[(Ie)$rest]} )) && return 1
+    seen+=( "$rest" )
+
     front=$front${rest[1,$mbegin[1]-1]}
     rest=${rest[$mbegin[1],-1]}
     case $rest[2] in
@@ -54,22 +59,10 @@ _fsh_make_expand_vars() {
     fi
 
     val=''
-    if [[ -n ${VAR_ARGS[(i)$var]} ]]; then
-      val=${VAR_ARGS[$var]}
-    else
-      if [[ -n $opt_args[(I)(-e|--environment-overrides)] ]]; then
-        if [[ $parameters[$var] == scalar-export* ]]; then
-          val=${(P)var}
-        elif [[ -n ${VARIABLES[(i)$var]} ]]; then
-          val=${VARIABLES[$var]}
-        fi
-      else
-        if [[ -n ${VARIABLES[(i)$var]} ]]; then
-          val=${VARIABLES[$var]}
-        elif [[ $parameters[$var] == scalar-export* ]]; then
-          val=${(P)var}
-        fi
-      fi
+    if [[ -n ${VARIABLES[(i)$var]} ]]; then
+      val=${VARIABLES[$var]}
+    elif [[ $parameters[$var] == scalar-export* ]]; then
+      val=${(P)var}
     fi
     rest=${rest//\$$open$var$close/$val}
   done
@@ -87,6 +80,24 @@ _fsh_make_parse_makefile() {
   while read input
   do
     case "$input " in
+      # VARIABLE = value OR VARIABLE ?= value
+      ([[:alnum:]][[:alnum:]_]#[" "$TAB]#(\?|)=*)
+      var=${input%%[ $TAB]#(\?|)=*}
+      val=${input#*=}
+      val=${val##[ $TAB]#}
+      VARIABLES[$var]=$val
+      ;;
+
+      # VARIABLE := value OR VARIABLE ::= value
+      # Evaluated immediately
+      ([[:alnum:]][[:alnum:]_]#[" "$TAB]#:(:|)=*)
+      var=${input%%[ $TAB]#:(:|)=*}
+      val=${input#*=}
+      val=${val##[ $TAB]#}
+      val=$(_fsh_make_expand_vars "$val")
+      VARIABLES[$var]=$val
+      ;;
+
       # TARGET: dependencies
       # TARGET1 TARGET2 TARGET3: dependencies
       ([[*?[:alnum:]$][^$TAB:=%]#:[^=]*)

--- a/tests/unit/main.zunit
+++ b/tests/unit/main.zunit
@@ -5,6 +5,26 @@
     _fsh_highlight_fill_option_variables
 }
 
+@test 'make target scan resolves Makefile variable assignments' {
+    local MATCH
+    local -a match mbegin mend reply2
+    integer MBEGIN MEND
+
+    unset '_fsh_state[chroma-make-cache]' '_fsh_state[chroma-make-cache-born-at]'
+    _fsh_make_targets <<'MAKE'
+ROOT = /usr
+PREFIX = $(ROOT)/local
+$(PREFIX)/install:
+LOOP = $(LOOP)
+$(LOOP)/never:
+plain:
+MAKE
+
+    assert "${reply2[1]}" same_as "/usr/local/install"
+    assert "${reply2[2]}" same_as "plain"
+    assert "${#reply2}" same_as "2"
+}
+
 @test 'ls /usr/bin' {
 reply=()
     PREBUFFER=""


### PR DESCRIPTION
# Pull request

## Summary

- Parse Makefile variable assignments before resolving target names.
- Remove dependencies on completion-only parameters that are absent in passive highlighting.
- Stop cyclic recursive expansion instead of blocking the line editor.

Closes #77

## Verification

- Focused regression passed with pinned ZUnit 0.8.2.
- All 14 standalone integration checks passed under Zsh 5.9.2.
- Native `zsh -n` and `zcompile` checks passed for all 68 classified sources.
- Trunk reported no issues in the two changed files.
- The full local ZUnit file reaches an unchanged style assertion failure (`fg=48` versus `fg=141`) after the new regression passes. CI remains the authoritative clean-environment suite result.

## Compatibility and lifecycle

No public API or lifecycle impact. This changes only Makefile target discovery inside the existing make chroma and retains the repository's Zsh 5.8 floor.

## Agent handoff

No handoff needed.
