### PR TITLE
fix(widgets): preserve third-party option state

### DIFF
--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -294,9 +294,7 @@ _fsh_cursor_moved() {
 # Helper for _fsh_bind_widgets
 # $1 is name of widget to call
 _fsh_call_widget() {
-  builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
-  builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
-
+  # The saved widget is third-party code and must inherit the caller's options.
   integer ret
   builtin zle "$@"
   ret=$?

--- a/tests/integration/test-plugin-lifecycle.zsh
+++ b/tests/integration/test-plugin-lifecycle.zsh
@@ -39,6 +39,63 @@ _fsh_test_count_value() {
   REPLY=$count
 }
 
+_fsh_test_widget_option_boundary() {
+  builtin emulate -L zsh
+
+  local fixture_root pty_name=fsyh-widget-options chunk output=
+  integer deadline
+
+  fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-widget-options.XXXXXXXX") || return 1
+  {
+    command mkdir -p -- "$fixture_root/home" "$fixture_root/zdotdir" || return 1
+    zmodload zsh/zpty || {
+      _fsh_test_fail 'zsh/zpty is unavailable'
+      return
+    }
+    zpty -b "$pty_name" \
+      "HOME=${(q)fixture_root}/home ZDOTDIR=${(q)fixture_root}/zdotdir zsh -f -i" || {
+        _fsh_test_fail 'cannot start isolated interactive Zsh'
+        return
+      }
+
+    zpty -w "$pty_name" \
+      "PS1='FSH_WIDGET> '; unsetopt prompt_cr prompt_sp warn_create_global; setopt auto_pushd; third_party_widget() { THIRD_PARTY_GLOBAL=1; builtin print -r -- FSH_WIDGET_OPTIONS:\${options[autopushd]}:\${options[warncreateglobal]}; zle .accept-line; }; zle -N third-party-widget third_party_widget; bindkey '^X^O' third-party-widget; source ${(q)plugin_path}; print -r -- FSH_WIDGET_READY"
+    deadline=$(( SECONDS + 10 ))
+    while (( SECONDS < deadline )); do
+      if zpty -r -t "$pty_name" chunk; then
+        output+=$chunk
+        [[ $output == *FSH_WIDGET_READY*FSH_WIDGET\>* ]] && break
+      else
+        command sleep 0.02
+      fi
+    done
+    [[ $output == *FSH_WIDGET_READY*FSH_WIDGET\>* ]] || {
+      _fsh_test_fail 'interactive widget probe did not become ready'
+      return
+    }
+
+    output=
+    zpty -w -n "$pty_name" $'\C-X\C-O'
+    deadline=$(( SECONDS + 10 ))
+    while (( SECONDS < deadline )); do
+      if zpty -r -t "$pty_name" chunk; then
+        output+=$chunk
+        [[ $output == *FSH_WIDGET_OPTIONS:*FSH_WIDGET\>* ]] && break
+      else
+        command sleep 0.02
+      fi
+    done
+
+    [[ $output == *FSH_WIDGET_OPTIONS:on:off* ]] ||
+      _fsh_test_fail "wrapped widget changed caller options: ${(V)output[1,1000]}"
+    [[ $output != *'created globally in function third_party_widget'* ]] ||
+      _fsh_test_fail 'wrapped widget enabled warn_create_global in third-party code'
+  } always {
+    (( ${+builtins[zpty]} )) && zpty -d "$pty_name" 2>/dev/null
+    command rm -rf -- "$fixture_root"
+  }
+}
+
 _fsh_test_noninteractive() {
   builtin emulate -L zsh
 
@@ -227,6 +284,9 @@ _fsh_test_interactive() {
     _fsh_test_fail 'interactive lifecycle case requires zsh -i'
     return
   }
+
+  _fsh_test_widget_option_boundary ||
+    _fsh_test_fail 'wrapped widget option boundary probe failed'
 
   zmodload zsh/parameter zsh/zleparameter || {
     _fsh_test_fail 'required observer modules are unavailable'

--- a/tests/unit/main.zunit
+++ b/tests/unit/main.zunit
@@ -1,6 +1,9 @@
 #!/usr/bin/env zunit
 @setup {
+    zstyle ':fsh:config' work-dir "${TMPDIR:-/tmp}/fsh-zunit-$$"
     load "../../F-Sy-H.plugin.zsh"
+    # Test this checkout even when the caller exports another F-Sy-H in FPATH.
+    fpath=( "$_fsh_base_dir"/{functions,completions,chroma} "${(@)fpath:#$_fsh_base_dir/(functions|completions|chroma)}" )
     setopt interactive_comments
     _fsh_highlight_fill_option_variables
 }


### PR DESCRIPTION
## Summary

- preserve caller option state while invoking saved third-party widgets
- add an isolated ZPTY regression covering `AUTO_PUSHD` and `WARN_CREATE_GLOBAL`
- isolate ZUnit from inherited `FPATH` and persisted theme state

Closes #133

## Verification

- pinned ZUnit 0.8.2 at `15061c83373be80b523988121b7ba12c6b2d82dc`: 22 passed, 0 failed locally
- exact-base reproduction at `b07fa329abe1a971c5d46d2710a0d0be347e9841`: 22 passed, 0 failed with the isolation fix
- all 10 GitHub checks pass on `787235cdb2e9d8ed26736864b4339b025b73ea88`
- `git diff --check` passes

## Compatibility and lifecycle

Wrapped third-party widgets now retain the option state present at invocation. F-Sy-H's internal highlighter remains option-isolated. There is no public configuration, compatibility-floor, or unload-contract change.

## Agent handoff

No handoff needed.
