### PR TITLE
feat(chroma): add semantic profiles for modern Git porcelain

### DIFF
--- a/chroma/_fsh_chroma_git
+++ b/chroma/_fsh_chroma_git
@@ -583,6 +583,115 @@ _fsh_chroma_git_def=(
                             <<>> NO-OP // ::_fsh_chroma_option_argument_action"
 
     ##
+    ## Modern porcelain positional arguments
+    ##
+
+    subcmd:switch "SWITCH_NEW_0_opt^ // SWITCH_DETACH_0_opt^ //
+                   SWITCH_BRANCH_1_arg // NO_MATCH_#_opt"
+
+    "SWITCH_NEW_0_opt^" "
+                (-c|-C|--orphan)
+                            <<>> NO-OP // ::_fsh_chroma_option_action
+             || (-c|-C|--orphan):del
+                            <<>> SWITCH_BRANCH_1_arg
+             || (-c|-C|--orphan):add
+                            <<>> NEW_BRANCH_1_arg // COMMIT_2_arg // NO_MATCH_#_arg"
+
+    "SWITCH_DETACH_0_opt^" "
+                --detach
+                            <<>> NO-OP // ::_fsh_chroma_option_action
+             || --detach:del
+                            <<>> SWITCH_BRANCH_1_arg
+             || --detach:add
+                            <<>> COMMIT_1_arg // NO_MATCH_#_arg"
+
+    SWITCH_BRANCH_1_arg "NO-OP // ::_fsh_chroma_git_verify_branch"
+
+    subcmd:restore "FILE_OR_DIR_#_arg // NO_MATCH_#_arg // NO_MATCH_#_opt"
+
+    subcmd:stash "STASH_REF_1_arg // STASH_BRANCH_1_arg // STASH_PUSH_1_arg //
+                  STASH_MESSAGE_1_arg // STASH_STORE_1_arg // STASH_NOARG_1_arg //
+                  FILE_OR_DIR_#_arg"
+
+    STASH_REF_1_arg "(show|drop|pop|apply) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                     del:FILE_OR_DIR_#_arg <<>>
+                     add:COMMIT_#_arg // NO_MATCH_#_arg"
+    STASH_BRANCH_1_arg "branch ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                        del:FILE_OR_DIR_#_arg <<>>
+                        add:NEW_BRANCH_2_arg // COMMIT_3_arg // NO_MATCH_#_arg"
+    STASH_PUSH_1_arg "push ::::: __style=${_fsh_theme_name}subcommand // NO-OP"
+    STASH_MESSAGE_1_arg "(save|create) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                         del:FILE_OR_DIR_#_arg <<>>
+                         add:STASH_MESSAGE_#_arg"
+    STASH_STORE_1_arg "store ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                       del:FILE_OR_DIR_#_arg <<>>
+                       add:COMMIT_#_arg // NO_MATCH_#_arg"
+    STASH_NOARG_1_arg "(list|clear) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                       del:FILE_OR_DIR_#_arg <<>>
+                       add:NO_MATCH_#_arg"
+    STASH_MESSAGE_\#_arg "__style=${_fsh_theme_name}optarg-string // NO-OP"
+
+    subcmd:rebase "COMMIT_1_arg // BRANCH_2_arg // NO_MATCH_#_arg // NO_MATCH_#_opt"
+    BRANCH_2_arg "NO-OP // ::_fsh_chroma_git_verify_branch"
+
+    subcmd:worktree "WORKTREE_ADD_1_arg // WORKTREE_MOVE_1_arg //
+                     WORKTREE_PATH_1_arg // WORKTREE_NOARG_1_arg"
+    WORKTREE_ADD_1_arg "add ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                        add:NEW_PATH_2_arg // COMMIT_3_arg // NO_MATCH_#_arg"
+    WORKTREE_MOVE_1_arg "move ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                         add:FILE_OR_DIR_2_arg // NEW_PATH_3_arg // NO_MATCH_#_arg"
+    WORKTREE_PATH_1_arg "(lock|remove|repair|unlock) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                         add:FILE_OR_DIR_#_arg // NO_MATCH_#_arg"
+    WORKTREE_NOARG_1_arg "(list|prune) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                          add:NO_MATCH_#_arg"
+    NEW_PATH_2_arg "NO-OP // ::_fsh_chroma_git_verify_new_path"
+    NEW_PATH_3_arg "NO-OP // ::_fsh_chroma_git_verify_new_path"
+    FILE_OR_DIR_2_arg "NO-OP // ::_fsh_chroma_git_verify_file_or_dir"
+
+    subcmd:submodule "SUBMODULE_ADD_1_arg // SUBMODULE_SET_URL_1_arg //
+                      SUBMODULE_PATH_1_arg // SUBMODULE_FOREACH_1_arg"
+    SUBMODULE_ADD_1_arg "add ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                         add:SUBMODULE_URL_2_arg // NEW_PATH_3_arg // NO_MATCH_#_arg"
+    SUBMODULE_SET_URL_1_arg "set-url ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                             add:FILE_OR_DIR_2_arg // SUBMODULE_URL_3_arg // NO_MATCH_#_arg"
+    SUBMODULE_PATH_1_arg "(status|init|deinit|update|set-branch|summary|sync|absorbgitdirs) ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                          add:FILE_OR_DIR_#_arg // NO_MATCH_#_arg"
+    SUBMODULE_FOREACH_1_arg "foreach ::::: __style=${_fsh_theme_name}subcommand // NO-OP <<>>
+                             add:SUBMODULE_COMMAND_#_arg"
+    SUBMODULE_URL_2_arg "NO-OP // ::_fsh_chroma_verify_url"
+    SUBMODULE_URL_3_arg "NO-OP // ::_fsh_chroma_verify_url"
+    SUBMODULE_COMMAND_\#_arg "__style=${_fsh_theme_name}optarg-string // NO-OP"
+
+    subcmd:branch "BRANCH_DELETE_0_opt^ // BRANCH_MOVE_COPY_0_opt^ //
+                   BRANCH_LIST_0_opt^ // BRANCH_NEW_1_arg // COMMIT_2_arg //
+                   NO_MATCH_#_opt"
+    "BRANCH_DELETE_0_opt^" "
+                (-d|-D)
+                            <<>> NO-OP // ::_fsh_chroma_option_action
+             || (-d|-D):del
+                            <<>> BRANCH_NEW_1_arg // COMMIT_2_arg
+             || (-d|-D):add
+                            <<>> BRANCH_EXISTING_#_arg // NO_MATCH_#_arg"
+    "BRANCH_MOVE_COPY_0_opt^" "
+                (-m|-M|-c|-C)
+                            <<>> NO-OP // ::_fsh_chroma_option_action
+             || (-m|-M|-c|-C):del
+                            <<>> BRANCH_NEW_1_arg // COMMIT_2_arg
+             || (-m|-M|-c|-C):add
+                            <<>> BRANCH_NAME_OR_NEW_1_arg // NEW_BRANCH_2_arg // NO_MATCH_#_arg"
+    "BRANCH_LIST_0_opt^" "
+                --list
+                            <<>> NO-OP // ::_fsh_chroma_option_action
+             || --list:del
+                            <<>> BRANCH_NEW_1_arg // COMMIT_2_arg
+             || --list:add
+                            <<>> BRANCH_PATTERN_#_arg"
+    BRANCH_NEW_1_arg "NO-OP // ::_fsh_chroma_git_verify_branch_name"
+    BRANCH_EXISTING_\#_arg "NO-OP // ::_fsh_chroma_git_verify_branch"
+    BRANCH_NAME_OR_NEW_1_arg "NO-OP // ::_fsh_chroma_git_verify_branch_or_new"
+    BRANCH_PATTERN_\#_arg "NO-OP // ::_fsh_chroma_verify_pattern"
+
+    ##
     ## All remaining subcommands
     ##
     ## {{{
@@ -981,6 +1090,18 @@ _fsh_chroma_git_verify_branch_name() {
     "$_wrd" != */ && "$_wrd" != *.lock && "$_wrd" != *\\* ]] && \
       { __style=${_fsh_theme_name}correct-subtle; return 0; } || \
       { __style=${_fsh_theme_name}incorrect-subtle; return 1; }
+}
+
+_fsh_chroma_git_verify_branch_or_new() {
+  _fsh_chroma_git_verify_branch "$@" && return 0
+  _fsh_chroma_git_verify_branch_name "$@"
+}
+
+_fsh_chroma_git_verify_new_path() {
+  local _wrd="$4" parent=${4:h}
+  [[ ! -e $_wrd && -d $parent ]] && \
+    { __style=${_fsh_theme_name}correct-subtle; return 0; } || \
+    { __style=${_fsh_theme_name}incorrect-subtle; return 1; }
 }
 
 # A generic handler that checks if given commit reference is correct

--- a/tests/integration/test-git-chroma-regions.zsh
+++ b/tests/integration/test-git-chroma-regions.zsh
@@ -13,13 +13,27 @@ typeset -gx XDG_CACHE_HOME=$fixture_root/cache-home
 typeset -gx _fsh_work_dir=$fixture_root/work
 command mkdir -p -- \
   "$ZDOTDIR" \
-  "$fixture_repo/some/folder/with/changes"
+  "$fixture_repo/some/folder/with/changes" \
+  "$fixture_repo/modules/demo"
 command touch -- \
   "$fixture_repo/some/file.lua" \
-  "$fixture_repo/some/folder/with/changes/changed.lua"
+  "$fixture_repo/some/folder/with/changes/changed.lua" \
+  "$fixture_repo/tracked.txt"
+
+command git init -q -b main "$fixture_repo"
+builtin cd -- "$fixture_repo"
+command git add -- some/file.lua some/folder/with/changes/changed.lua tracked.txt
+command git -c user.name=Fixture -c user.email=fixture@example.invalid \
+  commit -qm fixture
+command git branch topic
+command git worktree add -q --detach "$fixture_root/existing-worktree"
+builtin print -r -- changed >| tracked.txt
+command git stash push -qm fixture -- tracked.txt
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
-builtin cd -- "$fixture_repo"
+# Test this checkout even when the caller exports another F-Sy-H in FPATH.
+fpath=( "$_fsh_base_dir"/{functions,completions,chroma} "${(@)fpath:#$_fsh_base_dir/(functions|completions|chroma)}" )
+source "$plugin_root/tests/integration/chroma-fixture.zsh"
 
 _fsh_styles[correct-subtle]=fg=green
 _fsh_styles[incorrect-subtle]=fg=red
@@ -119,3 +133,70 @@ assert_trailing_token_style 'git commit missing/path/' fg=red || exit $?
 assert_trailing_token_style 'git commit --dry-run NOOUT' fg=cyan || exit $?
 assert_trailing_token_style 'git commit --dry-run NOOUT missing/path/' fg=red || exit $?
 assert_trailing_token_style 'git commit -m MESSAGE missing/path/' fg=red || exit $?
+
+fsh_assert_exact_regions 'git switch topic' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 16 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git switch missing' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 18 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git restore tracked.txt' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 11 ${_fsh_styles[subcommand]}" \
+  "12 23 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git restore missing.txt' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 11 ${_fsh_styles[subcommand]}" \
+  "12 23 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git stash pop stash@{0}' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 9 ${_fsh_styles[subcommand]}" \
+  "10 13 ${_fsh_styles[subcommand]}" \
+  "14 23 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git stash pop missing' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 9 ${_fsh_styles[subcommand]}" \
+  "10 13 ${_fsh_styles[subcommand]}" \
+  "14 21 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git rebase main topic' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 15 ${_fsh_styles[correct-subtle]}" \
+  "16 21 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git rebase main missing' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 15 ${_fsh_styles[correct-subtle]}" \
+  "16 23 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git worktree remove ../existing-worktree' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 12 ${_fsh_styles[subcommand]}" \
+  "13 19 ${_fsh_styles[subcommand]}" \
+  "20 40 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git worktree remove ../missing-worktree' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 12 ${_fsh_styles[subcommand]}" \
+  "13 19 ${_fsh_styles[subcommand]}" \
+  "20 39 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git submodule status modules/demo' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 13 ${_fsh_styles[subcommand]}" \
+  "14 20 ${_fsh_styles[subcommand]}" \
+  "21 33 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git submodule status modules/missing' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 13 ${_fsh_styles[subcommand]}" \
+  "14 20 ${_fsh_styles[subcommand]}" \
+  "21 36 ${_fsh_styles[incorrect-subtle]}" || exit $?
+fsh_assert_exact_regions 'git branch -d topic' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 13 ${_fsh_styles[single-hyphen-option]}" \
+  "14 19 ${_fsh_styles[correct-subtle]}" || exit $?
+fsh_assert_exact_regions 'git branch -d missing' \
+  "0 3 ${_fsh_styles[command]}" \
+  "4 10 ${_fsh_styles[subcommand]}" \
+  "11 13 ${_fsh_styles[single-hyphen-option]}" \
+  "14 21 ${_fsh_styles[incorrect-subtle]}" || exit $?

--- a/tests/integration/test-git-chroma-regions.zsh
+++ b/tests/integration/test-git-chroma-regions.zsh
@@ -20,7 +20,8 @@ command touch -- \
   "$fixture_repo/some/folder/with/changes/changed.lua" \
   "$fixture_repo/tracked.txt"
 
-command git init -q -b main "$fixture_repo"
+command git init -q "$fixture_repo"
+command git -C "$fixture_repo" symbolic-ref HEAD refs/heads/main
 builtin cd -- "$fixture_repo"
 command git add -- some/file.lua some/folder/with/changes/changed.lua tracked.txt
 command git -c user.name=Fixture -c user.email=fixture@example.invalid \


### PR DESCRIPTION
# Pull request

## Summary

- add semantic positional-argument profiles for `switch`, `restore`, `stash`, `rebase`, `worktree`, `submodule`, and `branch`
- reuse existing Git validators while retaining runtime-derived option discovery and the generic fallback
- cover valid and invalid representative operands with exact-region integration fixtures

Closes #70

## Verification

- repository-wide native Zsh syntax check
- all 14 standalone integration profiles
- ZUnit 0.8.2: 22 passed, 0 failed, 0 errors, 0 skipped
- `trunk check chroma/_fsh_chroma_git tests/integration/test-git-chroma-regions.zsh`
- highlight performance profile: 3.641 ms at 173 characters and 11.772 ms at 1,000 characters

## Compatibility and lifecycle

No compatibility or lifecycle impact. Runtime option discovery remains the option-spelling source of truth, and the change adds no new process execution.

## Agent handoff

No handoff needed.
