### PR TITLE
fix(chroma): validate declarative definitions

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -67,6 +67,7 @@ jobs:
           zsh -f tests/integration/test-highlight-performance.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
+          zsh -f tests/integration/test-chroma-validator.zsh
           zsh -f tests/integration/test-chroma-regions.zsh
           zsh -f tests/integration/test-async-chroma.zsh
           zsh -f tests/integration/test-theme-validator.zsh
@@ -139,6 +140,7 @@ jobs:
           zsh -f tests/integration/test-highlight-performance.zsh
           zsh -f tests/integration/test-theme-persistence.zsh
           zsh -f tests/integration/test-chroma-registry.zsh
+          zsh -f tests/integration/test-chroma-validator.zsh
           zsh -f tests/integration/test-chroma-regions.zsh
           zsh -f tests/integration/test-async-chroma.zsh
           zsh -f tests/integration/test-theme-validator.zsh

--- a/chroma/_fsh_chroma_git
+++ b/chroma/_fsh_chroma_git
@@ -183,7 +183,7 @@ _fsh_chroma_git_def=(
                 (-m)
                   <<>> NO-OP // ::_fsh_chroma_git_commit_message_action
                   <<>> NO-OP // ::_fsh_chroma_git_commit_message_argument_action
-                (-S|--gpg-sign=|--log=|-e|--strategy=|-X|--strategy-option=|-F|--file|--cleanup=|
+                || (-S|--gpg-sign=|--log=|-e|--strategy=|-X|--strategy-option=|-F|--file|--cleanup=|
                 --into-name=)
                   <<>> NO-OP // ::_fsh_chroma_option_action
                   <<>> NO-OP // ::_fsh_chroma_option_argument_action
@@ -341,8 +341,10 @@ _fsh_chroma_git_def=(
                         <<>> NEW_BRANCH_1_arg // COMMIT_2_arg // NO_MATCH_#_arg"
 
     NEW_BRANCH_1_arg "NO-OP // ::_fsh_chroma_git_verify_branch_name"
+    NEW_BRANCH_2_arg "NO-OP // ::_fsh_chroma_git_verify_branch_name"
 
     COMMIT_2_arg "NO-OP // ::_fsh_chroma_git_verify_commit"
+    COMMIT_3_arg "NO-OP // ::_fsh_chroma_git_verify_commit"
 
     CHECKOUT_0_opt "
                     (--conflict=|--recurse-submodules=|--track=|--pathspec-from-file=)
@@ -547,7 +549,7 @@ _fsh_chroma_git_def=(
              || -d:add
                             <<>> TAG_#_arg // NO_MATCH_#_opt
              || -d:del
-                            <<>> TAG_0_opt // TAG_NEW_1_arg // COMMIT_2_arg"
+                            <<>> TAG_0_opt^ // TAG_NEW_1_arg // COMMIT_2_arg"
 
     "TAG_#_arg" "NO-OP // ::_fsh_chroma_git_verify_tag_name"
 
@@ -557,7 +559,7 @@ _fsh_chroma_git_def=(
              || -l:add
                             <<>> TAG_L_0_opt // TAG_PAT_#_arg // NO_MATCH_#_opt
              || -l:del
-                            <<>> TAG_0_opt // TAG_NEW_1_arg // COMMIT_2_arg"
+                            <<>> TAG_0_opt^ // TAG_NEW_1_arg // COMMIT_2_arg"
 
     TAG_L_0_opt "
                 (-n|--contains|--no-contains|--points-at|--column=|--sort=|--format=|
@@ -575,7 +577,7 @@ _fsh_chroma_git_def=(
              || -v:add
                             <<>> TAG_V_0_opt // TAG_#_arg // NO_MATCH_#_opt
              || -v:del
-                            <<>> TAG_0_opt // TAG_NEW_1_arg // COMMIT_2_arg"
+                            <<>> TAG_0_opt^ // TAG_NEW_1_arg // COMMIT_2_arg"
 
     TAG_V_0_opt "
                 --format=

--- a/tests/integration/test-chroma-validator.zsh
+++ b/tests/integration/test-chroma-validator.zsh
@@ -1,0 +1,33 @@
+#!/usr/bin/env zsh
+
+builtin emulate -R zsh
+builtin setopt err_exit no_unset no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h:h}
+typeset -r fixture_root=$(command mktemp -d "${TMPDIR:-/tmp}/fsyh-chroma-validator.XXXXXXXX")
+trap 'command rm -rf -- "$fixture_root"' EXIT HUP INT TERM
+
+typeset output
+output=$(zsh -f "$plugin_root/tools/validate-chromas.zsh")
+[[ $output == *'/_fsh_chroma_git: ok (138 entries)'* ]]
+[[ $output == *'/_fsh_chroma_zi: ok (36 entries)'* ]]
+
+{
+  builtin print -r -- 'typeset -gA _fsh_chroma_bad_def=('
+  builtin print -r -- '  subcommands "(bad)"'
+  builtin print -r -- '  subcmd:NULL "MISSING_0_arg"'
+  builtin print -r -- '  MALFORMED_0_arg "NO-OP"'
+  builtin print -r -- '  UNKNOWN_HANDLER_0_arg "NO-OP // ::_fsh_chroma_missing"'
+  builtin print -r -- '  UNKNOWN_ACTION_0_arg "eval something // NO-OP"'
+  builtin print -r -- ')'
+} >| "$fixture_root/_fsh_chroma_bad"
+
+if output=$(zsh -f "$plugin_root/tools/validate-chromas.zsh" \
+  "$fixture_root/_fsh_chroma_bad" 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: invalid Chroma definition unexpectedly passed validation'
+  exit 1
+fi
+[[ $output == *': undefined-node: node is not defined: MISSING_0_arg'* ]]
+[[ $output == *': malformed-entry: expected action // handler'* ]]
+[[ $output == *': unknown-handler: function is not defined: _fsh_chroma_missing'* ]]
+[[ $output == *': unknown-action: unsupported action: "eval something"'* ]]

--- a/tools/validate-chromas.zsh
+++ b/tools/validate-chromas.zsh
@@ -1,0 +1,236 @@
+#!/usr/bin/env zsh
+
+builtin emulate -R zsh
+builtin setopt extended_glob no_function_argzero posix_argzero
+
+typeset -r plugin_root=${${(%):-%N}:A:h:h}
+typeset -g _fsh_theme_name=validator-
+typeset -gA _fsh_state ZI ZI_EXTS
+typeset -gA validation_keys
+typeset -ga validation_errors
+typeset -g validation_path validation_key
+typeset -g REPLY
+typeset -grA generic_handlers=(
+  _fsh_chroma_option_action 1
+  _fsh_chroma_option_argument_action 1
+  _fsh_chroma_option_separator_action 1
+  _fsh_chroma_verify_pattern 1
+  _fsh_chroma_verify_url 1
+)
+
+trim() {
+  REPLY=${1//((#s)[[:space:]]##|[[:space:]]##(#e))/}
+}
+
+validation_error() {
+  validation_errors+=( "$validation_path:$validation_key: $1: $2" )
+}
+
+validate_handler() {
+  local handler=$1
+
+  [[ $handler == NO-OP ]] && return 0
+  if [[ $handler != ::[A-Za-z_][A-Za-z0-9_]# ]]; then
+    validation_error malformed-handler "expected NO-OP or ::function, got ${(qqq)handler}"
+    return 0
+  fi
+  handler=${handler#::}
+  (( ${+generic_handlers[$handler]} || ${+functions[$handler]} )) ||
+    validation_error unknown-handler "function is not defined: $handler"
+}
+
+validate_action_record() {
+  local record=$1 action handler style
+  local -a fields
+
+  fields=( "${(@s://:)record}" )
+  fields=( "${fields[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
+  if (( $#fields != 2 )); then
+    validation_error malformed-entry "expected action // handler, got ${(qqq)record}"
+    return 0
+  fi
+
+  action=$fields[1]
+  handler=$fields[2]
+  if [[ $action != NO-OP ]]; then
+    if [[ $action != '__style='* ]]; then
+      validation_error unknown-action "unsupported action: ${(qqq)action}"
+    else
+      style=${action#__style=}
+      [[ $style == '${_fsh_theme_name}'* ]] && style=validator-${style#'${_fsh_theme_name}'}
+      [[ $style == [-[:alnum:]_]## ]] ||
+        validation_error unknown-action "invalid style action: ${(qqq)action}"
+    fi
+  fi
+  validate_handler "$handler"
+}
+
+validate_reference_list() {
+  local value=$1 reference
+  local -a references
+
+  references=( "${(@s://:)value}" )
+  references=( "${references[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
+  for reference in "${references[@]}"; do
+    if [[ -z $reference ]]; then
+      validation_error malformed-entry 'empty node reference'
+    elif (( ! ${+validation_keys[$reference]} )); then
+      validation_error undefined-node "node is not defined: $reference"
+    fi
+  done
+}
+
+validate_option_node() {
+  local value=$1 clause selector record
+  local -a clauses fields
+
+  clauses=( "${(@s:||:)value}" )
+  for clause in "${clauses[@]}"; do
+    fields=( "${(@s:<<>>:)clause}" )
+    fields=( "${fields[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
+    selector=$fields[1]
+    if [[ -z $selector || $#fields == 1 ]]; then
+      validation_error malformed-entry "option clause needs a selector and record: ${(qqq)clause}"
+      continue
+    fi
+    if [[ $selector == *:(add|del) ]]; then
+      (( $#fields == 2 )) ||
+        validation_error malformed-entry "directive clause has extra records: ${(qqq)clause}"
+      validate_reference_list "$fields[2]"
+      continue
+    fi
+    if (( $#fields > 3 )); then
+      validation_error malformed-entry "option clause has more than two action records: ${(qqq)clause}"
+      continue
+    fi
+    for record in "${(@)fields[2,-1]}"; do
+      validate_action_record "$record"
+    done
+  done
+}
+
+validate_argument_node() {
+  local value=$1 record directive operation reference
+  local -a fields references
+
+  fields=( "${(@s:<<>>:)value}" )
+  fields=( "${fields[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
+  record=$fields[1]
+  if [[ $record == *:::::* ]]; then
+    trim "${record%%:::::*}"
+    [[ -n $REPLY ]] || validation_error malformed-entry 'expected-value pattern is empty'
+    trim "${record#*:::::}"
+    record=$REPLY
+  fi
+  validate_action_record "$record"
+
+  (( $#fields >= 2 )) || return 0
+  for directive in "${(@)fields[2,-1]}"; do
+    references=( "${(@s://:)directive}" )
+    references=( "${references[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
+    operation=${references[1]%%:*}
+    reference=${references[1]#*:}
+    if [[ $operation != (add|del) || $reference == $references[1] ]]; then
+      validation_error malformed-entry "expected add:node or del:node, got ${(qqq)directive}"
+      continue
+    fi
+    references[1]=$reference
+    validate_reference_list "${(j: // :)references}"
+  done
+}
+
+validate_definition() {
+  local definition_name=$1 entry_name value handler
+  local -a keys
+
+  validation_keys=()
+  keys=( "${(@kP)definition_name}" )
+  for validation_key in "${keys[@]}"; do
+    validation_keys[$validation_key]=1
+  done
+
+  for validation_key in subcommands subcmd:NULL; do
+    (( ${+validation_keys[$validation_key]} )) ||
+      validation_error missing-entry "required entry is absent: $validation_key"
+  done
+
+  for validation_key in "${keys[@]}"; do
+    entry_name="${definition_name}[${validation_key}]"
+    value=${(P)entry_name}
+    case $validation_key in
+      subcommands)
+        if [[ $value == ::* ]]; then
+          handler=${value#::}
+          (( ${+functions[$handler]} )) ||
+            validation_error unknown-handler "function is not defined: $handler"
+        elif [[ -z $value ]]; then
+          validation_error malformed-entry 'subcommands must not be empty'
+        fi
+        ;;
+      subcmd-hook)
+        (( ${+functions[$value]} )) ||
+          validation_error unknown-handler "function is not defined: $value"
+        ;;
+      subcommands-blacklist)
+        ;;
+      subcmd:*)
+        [[ -n ${validation_key#subcmd:} ]] ||
+          validation_error malformed-entry 'subcommand selector is empty'
+        validate_reference_list "$value"
+        ;;
+      *)
+        if [[ $validation_key != [A-Za-z0-9_]##_(<->|\#)_(opt|arg)(\*|\^|) ]]; then
+          validation_error malformed-entry 'node name must end in _POSITION_opt or _POSITION_arg'
+        elif [[ $validation_key == *_opt(\*|\^|) ]]; then
+          validate_option_node "$value"
+        else
+          validate_argument_node "$value"
+        fi
+        ;;
+    esac
+  done
+}
+
+typeset -a definition_paths=( "$@" )
+typeset source_path source_text chroma_name definition_name
+integer initial_error_count
+
+if (( ! $#definition_paths )); then
+  for source_path in "$plugin_root"/chroma/_fsh_chroma_*(N-.); do
+    source_text=$(<"$source_path")
+    [[ $source_text == *'typeset -gA _fsh_chroma_'*'_def'* ]] && definition_paths+=( "$source_path" )
+  done
+fi
+
+if (( ! $#definition_paths )); then
+  builtin print -u2 -r -- 'f-sy-h: no Chroma definition files found'
+  exit 1
+fi
+
+for source_path in "${definition_paths[@]}"; do
+  validation_path=${source_path:A}
+  chroma_name=${source_path:t}
+  chroma_name=${chroma_name#_fsh_chroma_}
+  definition_name=_fsh_chroma_${chroma_name}_def
+  validation_key='<definition>'
+  initial_error_count=$#validation_errors
+  _fsh_state=()
+  builtin unset "$definition_name" 2>/dev/null
+  if ! source "$source_path"; then
+    validation_error source-failed 'definition file returned non-zero'
+    continue
+  fi
+  if [[ ${(tP)definition_name} != association ]]; then
+    validation_error missing-definition "expected associative array: $definition_name"
+    continue
+  fi
+  validate_definition "$definition_name"
+  if (( $#validation_errors == initial_error_count )); then
+    builtin print -r -- "$validation_path: ok (${#${(kP)definition_name}} entries)"
+  fi
+done
+
+if (( $#validation_errors )); then
+  builtin print -u2 -rl -- "${validation_errors[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a standalone validator for every declarative Chroma definition
- run negative validator coverage on Zsh 5.8 and 5.9.2 in CI
- repair malformed and dangling Git definition entries exposed by validation

## Verification

- `zsh -f tools/validate-chromas.zsh`
- `zsh -f tests/integration/test-chroma-validator.zsh`
- `zunit` (22 passed)
- focused Git and Chroma integration tests
- `trunk check` on changed files

`actionlint` retains the existing SC2251 finding in an untouched workflow block.

Refs #74
