### PR TITLE
feat(chroma): add introspection command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ requirement.
 
 Public shell API:
 
-- functions: `fsh_theme`, `fsh_plugin_unload`
+- functions: `fsh_chroma`, `fsh_theme`, `fsh_plugin_unload`
 - configuration: `zstyle ':fsh:config' ...`
 - private state and callbacks: `_fsh_*`
 

--- a/F-Sy-H.plugin.zsh
+++ b/F-Sy-H.plugin.zsh
@@ -409,6 +409,7 @@ zmodload zsh/parameter 2>/dev/null
 zmodload zsh/system 2>/dev/null
 
 builtin autoload -Uz -- is-at-least \
+  fsh_chroma \
   _fsh_read_ini _fsh_theme_color_rgb _fsh_theme_color_cvd_lab \
   _fsh_theme_resolve_rendering _fsh_validate_theme_contrast \
   _fsh_validate_theme_cvd_separation _fsh_validate_theme_distinguishability \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - Provides command-specific chroma highlighters for tools such as Git, Docker,
   grep, and make.
 - Supports shipped and user-defined themes through `fsh_theme`.
+- Inspects command-specific highlighters and their health through `fsh_chroma`.
 - Highlights nested command substitutions, arithmetic, strings, paths, and
   shell control structures.
 
@@ -47,13 +48,14 @@
 
 - Project identifier: `fsh`
 - Authoritative entrypoint: `F-Sy-H.plugin.zsh`
-- Public functions: `fsh_theme` and `fsh_plugin_unload`
+- Public functions: `fsh_chroma`, `fsh_theme`, and `fsh_plugin_unload`
 - Public configuration context: `:fsh:config`
 - Autoload paths: `functions/`, `completions/`, and the private `chroma/`
 
 The plugin has no public aliases or public parameters. Persistent implementation
 state and callbacks use the private `_fsh_` prefix. Native completion naming is
-the one required exception: the completion for `fsh_theme` is `_fsh_theme`.
+the required exceptions: completions for `fsh_chroma` and `fsh_theme` are
+`_fsh_chroma` and `_fsh_theme`.
 
 ### Repository layout
 
@@ -70,7 +72,7 @@ the one required exception: the completion for `fsh_theme` is `_fsh_theme`.
 
 ### Owned shell state
 
-- Public functions: `fsh_theme` and `fsh_plugin_unload`
+- Public functions: `fsh_chroma`, `fsh_theme`, and `fsh_plugin_unload`
 - Private persistent functions and parameters: names beginning with `_fsh_`
 - Direct module requests: `zsh/parameter`, `zsh/system`, optional
   `zsh/nearcolor`, and interactive-only `zsh/zleparameter`
@@ -233,6 +235,31 @@ Theme file examples and additional usage guidance are documented in the
 [wiki guide](https://wiki.zshell.dev/ecosystem/plugins/f-sy-h).
 
 ## Usage
+
+List registered command highlighters and classify files that are not directly
+registered:
+
+```zsh
+fsh_chroma list
+```
+
+Check registry reachability, declarative definitions, active theme styles, and
+session-disabled asynchronous lookups:
+
+```zsh
+fsh_chroma doctor
+```
+
+Add a nine-run median of end-to-end highlighting time for one command line:
+
+```zsh
+fsh_chroma doctor --sample 'docker image rm deadbeef'
+```
+
+The sample runs outside active ZLE, so it does not start asynchronous lookup
+workers. It measures the complete highlighting pass, not isolated chroma
+function time. `doctor` returns status `0` when healthy and `1` when it finds a
+problem; invalid command usage returns status `2`.
 
 List available themes:
 

--- a/completions/_fsh_chroma
+++ b/completions/_fsh_chroma
@@ -1,0 +1,14 @@
+#compdef fsh_chroma
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+if [[ $words[2] == doctor ]]; then
+  _arguments \
+    '1:action:(list doctor)' \
+    '--sample[measure end-to-end highlighting time]:command line:'
+else
+  _arguments '1:action:(list doctor)'
+fi

--- a/functions/_fsh_async_command
+++ b/functions/_fsh_async_command
@@ -49,6 +49,7 @@ if (( ${_fsh_state[$key-pending]:-0} )); then
     fi
     _fsh_state[$key-pending]=0
     _fsh_state[$key-disabled]=1
+    _fsh_state[$key-disabled-reason]="timeout after ${_fsh_chroma_timeout_seconds}s"
     if (( ! ${_fsh_state[$key-warned]:-0} )); then
       zle -M "f-sy-h: disabled slow chroma lookup: $key"
       _fsh_state[$key-warned]=1

--- a/functions/fsh_chroma
+++ b/functions/fsh_chroma
@@ -19,6 +19,7 @@ tree_roles=(
   _fsh_chroma_which opt-in
   _fsh_chroma_zi provider
 )
+[[ $OSTYPE == darwin* ]] && tree_roles[_fsh_chroma_whatis]=platform-disabled
 
 if (( $# )); then
   shift

--- a/functions/fsh_chroma
+++ b/functions/fsh_chroma
@@ -1,0 +1,189 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+builtin emulate -L zsh
+builtin setopt extended_glob warn_create_global typeset_silent no_short_loops rc_quotes no_auto_pushd
+
+{
+local action=${1-} sample= key target handler source_file role style style_key
+local command_name validator_output reason row_status kind theme_manager=enabled
+local -a registry_keys source_files samples
+local -A registry_targets tree_roles
+integer failures=0 missing_styles=0 sample_requested=0 run
+
+tree_roles=(
+  _fsh_chroma_example documentation
+  _fsh_chroma_git provider
+  _fsh_chroma_ogit retired
+  _fsh_chroma_vim opt-in
+  _fsh_chroma_which opt-in
+  _fsh_chroma_zi provider
+)
+
+if (( $# )); then
+  shift
+else
+  builtin print -u2 -r -- 'usage: fsh_chroma list | fsh_chroma doctor [--sample command-line]'
+  return 2
+fi
+
+case $action in
+  list)
+    (( $# == 0 )) || {
+      builtin print -u2 -r -- 'usage: fsh_chroma list'
+      return 2
+    }
+    ;;
+  doctor)
+    if (( $# == 2 )) && [[ $1 == --sample ]]; then
+      sample_requested=1
+      sample=$2
+    elif (( $# != 0 )); then
+      builtin print -u2 -r -- 'usage: fsh_chroma doctor [--sample command-line]'
+      return 2
+    fi
+    ;;
+  *)
+    builtin print -u2 -r -- 'usage: fsh_chroma list | fsh_chroma doctor [--sample command-line]'
+    return 2
+    ;;
+esac
+
+for key in ${(ok)_fsh_state}; do
+  target=${_fsh_state[$key]-}
+  [[ $key == chroma-* && $target == _fsh_chroma_* ]] || continue
+  registry_keys+=( "$key" )
+  registry_targets[${target%%%*}]=1
+done
+source_files=( "$_fsh_base_dir"/chroma/_fsh_chroma_*(N-.) )
+zstyle -s ':fsh:config' theme-manager theme_manager || theme_manager=enabled
+
+if [[ $action == list ]]; then
+  builtin print -r -- $'COMMAND\tTARGET\tKIND\tSTATUS'
+  for key in "${registry_keys[@]}"; do
+    command_name=${key#chroma-}
+    target=${_fsh_state[$key]}
+    handler=${target%%%*}
+    source_file=$_fsh_base_dir/chroma/$handler
+    kind=dedicated
+    [[ $handler == _fsh_chroma_subcommand ]] && kind=generic
+    if [[ $handler == _fsh_chroma_theme && $theme_manager == (disabled|false|no|off|0) ]]; then
+      row_status=disabled
+    else
+      row_status=ready
+      (( ${+functions[$handler]} )) && [[ -r $source_file ]] || row_status=missing
+    fi
+    builtin print -r -- "$command_name"$'\t'"$target"$'\t'"$kind"$'\t'"$row_status"
+  done
+  builtin print -r -- $'\nTREE-ONLY\tROLE'
+  for source_file in "${source_files[@]}"; do
+    handler=${source_file:t}
+    (( ${+registry_targets[$handler]} )) && continue
+    builtin print -r -- "$handler"$'\t'"${tree_roles[$handler]:-unclassified}"
+  done
+  return 0
+fi
+
+builtin print -r -- 'fsh_chroma doctor'
+builtin print -r -- 'ok registry loaded without duplicate keys'
+
+for key in "${registry_keys[@]}"; do
+  target=${_fsh_state[$key]}
+  handler=${target%%%*}
+  source_file=$_fsh_base_dir/chroma/$handler
+  if [[ $handler == _fsh_chroma_theme && $theme_manager == (disabled|false|no|off|0) ]]; then
+    builtin print -r -- 'info registry target configured disabled: fsh_theme'
+    continue
+  fi
+  if (( ! ${+functions[$handler]} )) || [[ ! -r $source_file ]]; then
+    builtin print -u2 -r -- "error registry target is not loadable: ${key#chroma-} -> $target"
+    (( ++failures ))
+  fi
+done
+(( failures )) || builtin print -r -- \
+  "ok registry handlers: $#registry_keys commands, $#registry_targets targets"
+
+for source_file in "${source_files[@]}"; do
+  handler=${source_file:t}
+  (( ${+registry_targets[$handler]} )) && continue
+  role=${tree_roles[$handler]-}
+  if [[ -z $role ]]; then
+    builtin print -u2 -r -- "error unclassified tree-only chroma: $handler"
+    (( ++failures ))
+  else
+    builtin print -r -- "info tree-only chroma: $handler ($role)"
+  fi
+done
+
+if validator_output=$(command zsh -f "$_fsh_base_dir/tools/validate-chromas.zsh" 2>&1); then
+  local -a validator_lines=( "${(@f)validator_output}" )
+  builtin print -r -- "ok declarative definitions: $#validator_lines files"
+else
+  builtin print -u2 -r -- 'error declarative chroma validation failed'
+  [[ -n $validator_output ]] && builtin print -u2 -r -- "$validator_output"
+  (( ++failures ))
+fi
+
+for style in "${_fsh_theme_style_order[@]}"; do
+  style_key=${_fsh_theme_name}${style}
+  (( ${+_fsh_styles[$style_key]} )) || {
+    builtin print -u2 -r -- "error active theme style is unresolved: $style"
+    (( ++missing_styles ))
+  }
+done
+(( failures += missing_styles ))
+(( missing_styles )) || builtin print -r -- \
+  "ok active theme: ${_fsh_theme_name:-default} ($#_fsh_theme_style_order resolved styles)"
+
+for key in ${(ok)_fsh_state}; do
+  [[ $key == *-disabled ]] || continue
+  (( ${_fsh_state[$key]:-0} )) || continue
+  reason=${_fsh_state[${key%-disabled}-disabled-reason]:-reason not recorded}
+  builtin print -r -- "warning async lookup disabled: ${key%-disabled} ($reason)"
+done
+
+if (( sample_requested )); then
+  (
+    local command_word sample_target sample_handler
+    local -a reply=()
+    local -A measured_handlers
+    local -F6 SECONDS median
+    typeset BUFFER=$sample PREBUFFER=
+
+    _fsh_highlight_init
+    _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0 || return 1
+    for run in {1..9}; do
+      reply=()
+      SECONDS=0
+      _fsh_highlight_process "$PREBUFFER" "$BUFFER" 0 || return 1
+      samples+=( "$SECONDS" )
+    done
+    samples=( ${(on)samples} )
+    median=$samples[5]
+
+    for command_word in "${_fsh_last_commands[@]}"; do
+      command_name=${${(Q)command_word}:t}
+      sample_target=${_fsh_state[chroma-$command_name]-}
+      [[ $sample_target == _fsh_chroma_* ]] || continue
+      measured_handlers[$command_name]=$sample_target
+    done
+
+    builtin printf 'sample end-to-end median: %.6fs (9 runs)\n' "$median"
+    if (( $#measured_handlers )); then
+      for command_name in ${(ok)measured_handlers}; do
+        sample_handler=${measured_handlers[$command_name]}
+        builtin print -r -- "sample handler: $command_name -> $sample_handler"
+      done
+    else
+      builtin print -r -- 'sample handler: none'
+    fi
+  ) || {
+    builtin print -u2 -r -- 'error sample highlighting failed'
+    (( ++failures ))
+  }
+fi
+
+(( failures == 0 ))
+} always {
+  _fsh_lifecycle_refresh
+}

--- a/lib/lifecycle.zsh
+++ b/lib/lifecycle.zsh
@@ -9,7 +9,7 @@ _fsh_lifecycle_function_owned() {
 
   case $1 in
     (_fsh_lifecycle_*) return 1 ;;
-    (_fsh_*|fsh_theme|add-zsh-hook|is-at-least|colors) return 0 ;;
+    (_fsh_*|fsh_chroma|fsh_theme|add-zsh-hook|is-at-least|colors) return 0 ;;
     (*) return 1 ;;
   esac
 }

--- a/tests/integration/test-async-chroma.zsh
+++ b/tests/integration/test-async-chroma.zsh
@@ -54,6 +54,9 @@ command chmod 755 "$fixture_root/bin/docker"
 } >| "$fixture_root/bin/git"
 command chmod 755 "$fixture_root/bin/git"
 zstyle ':fsh:config' work-dir "$fixture_root/work"
+# Test this checkout even when the caller exports another F-Sy-H in FPATH.
+fpath=( "$plugin_root"/{functions,completions,chroma} \
+  "${(@)fpath:#$plugin_root/(functions|completions|chroma)}" )
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
 
@@ -71,6 +74,14 @@ elapsed=$(( EPOCHREALTIME - started ))
 (( elapsed < 0.250 ))
 [[ ! -e $FSH_DOCKER_MARKER ]]
 (( ! ${_fsh_state[chroma-docker-list-pending]:-0} ))
+
+_fsh_state[chroma-timeout-fixture-pending]=1
+_fsh_state[chroma-timeout-fixture-started-at]=$(( SECONDS - _fsh_chroma_timeout_seconds ))
+_fsh_state[chroma-timeout-fixture-warned]=1
+_fsh_async_command chroma-timeout-fixture command true
+(( _fsh_state[chroma-timeout-fixture-disabled] ))
+[[ ${_fsh_state[chroma-timeout-fixture-disabled-reason]} == \
+  "timeout after ${_fsh_chroma_timeout_seconds}s" ]]
 
 fsh_plugin_unload
 

--- a/tests/integration/test-chroma-registry.zsh
+++ b/tests/integration/test-chroma-registry.zsh
@@ -14,6 +14,8 @@ zstyle ':fsh:config' work-dir "$fixture_root/work"
 
 source "$plugin_root/F-Sy-H.plugin.zsh"
 
+(( ${+functions[fsh_chroma]} ))
+
 (( ! ${+_fsh_state[chroma-example]} ))
 (( ! ${+_fsh_state[chroma-vim]} ))
 (( ! ${+_fsh_state[chroma-which]} ))
@@ -57,9 +59,55 @@ for function_name in ${(k)functions}; do
   }
 done
 
+typeset output
+output=$(fsh_chroma list)
+[[ $output == *$'COMMAND\tTARGET\tKIND\tSTATUS'* ]]
+[[ $output == *$'docker\t_fsh_chroma_docker\tdedicated\tready'* ]]
+[[ $output == *$'_fsh_chroma_ogit\tretired'* ]]
+
+output=$(fsh_chroma doctor)
+[[ $output == *'ok registry loaded without duplicate keys'* ]]
+[[ $output == *'ok declarative definitions:'* ]]
+[[ $output == *'ok active theme: default'* ]]
+
+output=$(fsh_chroma doctor --sample 'docker image rm deadbeef')
+[[ $output == *'sample end-to-end median:'* ]]
+[[ $output == *'sample handler: docker -> _fsh_chroma_docker'* ]]
+
+_fsh_state[chroma-test-disabled]=1
+_fsh_state[chroma-test-disabled-reason]='fixture timeout'
+output=$(fsh_chroma doctor)
+[[ $output == *'warning async lookup disabled: chroma-test (fixture timeout)'* ]]
+builtin unset '_fsh_state[chroma-test-disabled]' '_fsh_state[chroma-test-disabled-reason]'
+
+_fsh_state[chroma-test-missing]=_fsh_chroma_missing
+if output=$(fsh_chroma doctor 2>&1); then
+  builtin print -u2 -r -- 'f-sy-h: chroma doctor accepted an unreachable registry target'
+  exit 1
+fi
+[[ $output == *'error registry target is not loadable: test-missing -> _fsh_chroma_missing'* ]]
+builtin unset '_fsh_state[chroma-test-missing]'
+
+if fsh_chroma doctor --unknown >/dev/null 2>&1; then
+  builtin print -u2 -r -- 'f-sy-h: invalid fsh_chroma arguments unexpectedly succeeded'
+  exit 1
+fi
+
 fsh_plugin_unload
 
-typeset output
+output=$(ZDOTDIR=$fixture_root/disabled-zdotdir XDG_CACHE_HOME=$fixture_root/disabled-cache \
+  zsh -f -c '
+    zstyle ":fsh:config" work-dir "$1"
+    zstyle ":fsh:config" theme-manager disabled
+    source "$2/F-Sy-H.plugin.zsh"
+    fsh_chroma doctor
+    fsh_plugin_unload
+  ' zsh "$fixture_root/disabled-work" "$plugin_root" 2>&1) || {
+    builtin print -u2 -r -- "f-sy-h: chroma doctor rejected a disabled theme manager: $output"
+    exit 1
+  }
+[[ $output == *'info registry target configured disabled: fsh_theme'* ]]
+
 output=$(ZDOTDIR=$fixture_root/opt-in-zdotdir XDG_CACHE_HOME=$fixture_root/opt-in-cache \
   zsh -f -c '
     zstyle ":fsh:config" work-dir "$1"

--- a/tests/integration/test-chroma-registry.zsh
+++ b/tests/integration/test-chroma-registry.zsh
@@ -64,6 +64,7 @@ output=$(fsh_chroma list)
 [[ $output == *$'COMMAND\tTARGET\tKIND\tSTATUS'* ]]
 [[ $output == *$'docker\t_fsh_chroma_docker\tdedicated\tready'* ]]
 [[ $output == *$'_fsh_chroma_ogit\tretired'* ]]
+[[ $OSTYPE != darwin* || $output == *$'_fsh_chroma_whatis\tplatform-disabled'* ]]
 
 output=$(fsh_chroma doctor)
 [[ $output == *'ok registry loaded without duplicate keys'* ]]

--- a/tests/integration/test-function-completion.zsh
+++ b/tests/integration/test-function-completion.zsh
@@ -58,8 +58,8 @@ _fsh_test_read_until() {
   fi
 
   if (( test_status == 0 )); then
-    zpty -w "$pty_name" "zstyle ':fsh:config' work-dir ${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D -i; PS1='FSH_INTERRUPT_READY> '; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}"
-    _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]*FSH_INTERRUPT_READY*' || \
+    zpty -w "$pty_name" "zstyle ':fsh:config' work-dir ${(q)test_dir}; source ${(q)plugin_path}; autoload -Uz compinit; compinit -D -i; PS1='FSH_INTERRUPT_READY> '; print -r -- FSH_\${:-LOAD}_NEW:\${+functions[_fsh_highlight_process]}:OLD:\${+functions[-fast-highlight-process]}:CHROMA:\${_comps[fsh_chroma]-}"
+    _fsh_test_read_until '*FSH_LOAD_NEW:[01]:OLD:[01]:CHROMA:_fsh_chroma*FSH_INTERRUPT_READY*' || \
       _fsh_test_fail "F-Sy-H did not load in the interactive Zsh: ${(V)REPLY[1,1000]}"
     load_output=$REPLY
   fi
@@ -75,6 +75,8 @@ _fsh_test_read_until() {
 
   [[ $load_output == *FSH_LOAD_NEW:1:OLD:0* ]] || \
     _fsh_test_fail 'plugin did not expose only the private _fsh helper namespace'
+  [[ $load_output == *CHROMA:_fsh_chroma* ]] || \
+    _fsh_test_fail 'compinit did not register the fsh_chroma completion'
   [[ $completion_output != *-fast-highlight* && $completion_output != *-fsh_sy_h* ]] || \
     _fsh_test_fail 'dash-prefixed F-Sy-H functions leaked into time completion'
 } always {

--- a/tests/integration/test-hostile-autoloads.zsh
+++ b/tests/integration/test-hostile-autoloads.zsh
@@ -31,6 +31,13 @@ _fsh_test_ini_parsed || {
   exit 1
 }
 
+typeset chroma_output
+chroma_output=$(fsh_chroma list) || exit 1
+[[ $chroma_output == *$'docker\t_fsh_chroma_docker\tdedicated\tready'* ]] || {
+  builtin print -u2 -r -- 'fsh_chroma failed under hostile caller options'
+  exit 1
+}
+
 [[ -o ksharrays && -o shwordsplit && -o globsubst ]] || {
   builtin print -u2 -r -- 'autoload function changed caller options'
   exit 1

--- a/tests/integration/test-plugin-lifecycle.zsh
+++ b/tests/integration/test-plugin-lifecycle.zsh
@@ -136,7 +136,7 @@ _fsh_test_noninteractive() {
 
     for name in ${(k)functions}; do
       case $name in
-        (_fsh_*|fsh_theme|add-zsh-hook|is-at-least|colors)
+        (_fsh_*|fsh_chroma|fsh_theme|add-zsh-hook|is-at-least|colors)
           before_owned_functions[$name]=${functions[$name]}
           ;;
       esac
@@ -171,6 +171,8 @@ _fsh_test_noninteractive() {
       _fsh_test_fail 'non-interactive loading installed a preexec hook'
 
     command mkdir -p -- "$_fsh_work_dir"
+    fsh_chroma list >/dev/null ||
+      _fsh_test_fail 'cannot exercise the chroma command before unload'
     fsh_theme --secondary --quiet default ||
       _fsh_test_fail 'cannot exercise lazy theme functions before unload'
     if (( ${+before_owned_functions[colors]} )); then
@@ -241,7 +243,7 @@ _fsh_test_noninteractive() {
 
     for name in ${(k)functions}; do
       case $name in
-        (_fsh_*|fsh_theme|add-zsh-hook|is-at-least|colors)
+        (_fsh_*|fsh_chroma|fsh_theme|add-zsh-hook|is-at-least|colors)
           (( ${+before_owned_functions[$name]} )) ||
             [[ $name == _fsh_buffer_modified ]] || {
               _fsh_test_fail "unload left a lazy plugin function: $name"


### PR DESCRIPTION
## Summary

- add `fsh_chroma list` inventory for registered and tree-only chromas
- add `fsh_chroma doctor` checks for registry reachability, declarative definitions, active theme styles, disabled async lookups, and optional sample timing
- add native completion, lifecycle cleanup, timeout reasons, documentation, and integration coverage

Closes #78

## Verification

- Trunk 1.25.0: 12 changed files checked, no issues
- Zsh 5.9.2: 71 native sources parsed and compiled
- ZUnit 0.8.2: 22 passed, 0 failed
- focused integration profiles passed for entrypoint, lifecycle, completion, chroma registry and regions, async behavior, passive safety, hostile autoload options, performance, themes, and validators
- Zsh 5.8 on Ubuntu 20.04: new autoloads compiled and focused registry, lifecycle, and async profiles passed

## Compatibility and lifecycle

This adds the public `fsh_chroma` autoload function and `_fsh_chroma` completion while retaining the Zsh 5.8 floor. Materializing the command participates in the existing unload lifecycle. Plugin loading gains no network or filesystem activity, aliases, parameters, hooks, widgets, or modules.

The issue uses the legacy `fast-chroma` name; this implementation uses the Standard v2 `fsh_chroma` namespace. Duplicate registry keys are already rejected during plugin load, and `doctor` reports that guard. Sample timing runs in a subshell outside active ZLE, reports end-to-end highlighting time with handler attribution, and does not start async workers. Portable runtime fork tracing is not added; the existing async integration profile remains the executable synchronous-fork check.

## Instruction impact review

1. Classification: repository-local scoped guidance summarizing the public plugin API.
2. Consumers: Codex, Claude Code, Copilot, Gemini CLI, maintainers, and contributors working in F-Sy-H.
3. Canonical owner: `README.md` remains the public API owner; `AGENTS.md` only mirrors the function list for repository orientation.
4. Duplication and conflicts: the README, lifecycle ownership, and AGENTS summary now agree on `fsh_chroma`, `fsh_theme`, and `fsh_plugin_unload`.
5. Manifests: F-Sy-H has no local instruction manifest, and no organization or private route changes are required.
6. Runtime delivery: supported runtimes receive the repository-root `AGENTS.md` directly without relying on an optional hook or skill.
7. Generated output and limits: no generated instruction output is affected; Trunk and diff checks pass, and the private root composite is unchanged.

## Agent handoff

No handoff needed.
